### PR TITLE
prince-archiver: Separate Settings

### DIFF
--- a/prince-archiver/alembic/env.py
+++ b/prince-archiver/alembic/env.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from logging.config import fileConfig
 
 from sqlalchemy import pool
@@ -6,7 +7,6 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
-from prince_archiver.config import get_settings
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -30,8 +30,11 @@ target_metadata = Base.metadata
 
 
 def get_url() -> str:
-    settings = get_settings()
-    return str(settings.POSTGRES_DSN)
+    dsn = os.getenv(
+        "POSTGRES_DSN",
+        "asyncpg+postsgresql://postgres:postgres@localhost:5432/postgres",
+    )
+    return dsn
 
 
 def run_migrations_offline() -> None:

--- a/prince-archiver/compose.dev.yml
+++ b/prince-archiver/compose.dev.yml
@@ -1,12 +1,5 @@
 version: "3.8"
 
-x-dev-env-variables: &dev-env-variables
-  AWS_BUCKET_NAME: mycostreams
-  AWS_ACCESS_KEY_ID: aws-access-key-id
-  AWS_SECRET_ACCESS_KEY: aws-access-key-id
-  AWS_ENDPOINT_URL: http://s3:9090
-
-
 services:
   prince:
     image: prince-archiver
@@ -19,13 +12,16 @@ services:
       - ./alembic/:/app/alembic
 
   watcher:
-    environment: *dev-env-variables
     volumes:
     - ./prince_archiver:/app/prince_archiver
     - ./alembic:/app/alembic
 
   worker:
-    environment: *dev-env-variables
+    environment:
+      - AWS_BUCKET_NAME=mycostreams
+      - AWS_ACCESS_KEY_ID=aws-access-key-id
+      - AWS_SECRET_ACCESS_KEY=aws-access-key-id
+      - AWS_ENDPOINT_URL=http://s3:9090
     volumes:
     - ./prince_archiver:/app/prince_archiver
     - ./alembic/:/app/alembic

--- a/prince-archiver/compose.yml
+++ b/prince-archiver/compose.yml
@@ -2,12 +2,8 @@ version: "3.8"
 
 x-env-variables: &env-variables
   DATA_DIR: /data/input/
-  ARCHIVE_DIR: /data/archive/
   REDIS_DSN: redis://redis:6379
-  AWS_BUCKET_NAME: mycostreams
-  AWS_ACCESS_KEY_ID: aws-access-key-id
-  AWS_SECRET_ACCESS_KEY: aws-access-key-id
-  POSTGRES_DSN: postgresql+asyncpg://postgres:postgres@db:5432/postgres
+
 
 services:
 
@@ -15,7 +11,9 @@ services:
     image: prince-archiver
     build:
       context: .
-    environment: *env-variables
+    environment: 
+      <<: *env-variables
+      POSTGRES_DSN: postgresql+asyncpg://postgres:postgres@db:5432/postgres
     command: ["python", "-m", "prince_archiver.entrypoints.watcher"]
     volumes:
     - input_data:/data/input
@@ -28,7 +26,9 @@ services:
   worker:
     image: prince-archiver
     command: ["arq", "prince_archiver.worker.WorkerSettings"]
-    environment: *env-variables
+    environment: 
+      <<: *env-variables
+      ARCHIVE_DIR: /data/archive/
     volumes:
     - input_data:/data/input
     - archive_data:/data/archive

--- a/prince-archiver/prince_archiver/config.py
+++ b/prince-archiver/prince_archiver/config.py
@@ -12,19 +12,11 @@ sentry_sdk.init(
 )
 
 
-class Settings(BaseSettings):
+class CommonSettings(BaseSettings):
 
-    POSTGRES_DSN: PostgresDsn
     REDIS_DSN: RedisDsn
 
-    AWS_ACCESS_KEY_ID: str
-    AWS_SECRET_ACCESS_KEY: str
-    AWS_BUCKET_NAME: str
-    AWS_ENDPOINT_URL: str | None = None
-    AWS_REGION_NAME: str | None = None
-
     DATA_DIR: Path
-    ARCHIVE_DIR: Path
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -33,6 +25,22 @@ class Settings(BaseSettings):
     )
 
 
+class WatcherSettings(CommonSettings):
+
+    POSTGRES_DSN: PostgresDsn
+
+
+class WorkerSettings(CommonSettings):
+
+    AWS_ACCESS_KEY_ID: str
+    AWS_SECRET_ACCESS_KEY: str
+    AWS_BUCKET_NAME: str
+    AWS_ENDPOINT_URL: str | None = None
+    AWS_REGION_NAME: str | None = None
+
+    ARCHIVE_DIR: Path
+
+
 @lru_cache
-def get_settings() -> Settings:
-    return Settings()
+def get_worker_settings() -> WorkerSettings:
+    return WorkerSettings()

--- a/prince-archiver/prince_archiver/entrypoints/watcher.py
+++ b/prince-archiver/prince_archiver/entrypoints/watcher.py
@@ -6,7 +6,7 @@ from arq import create_pool
 from arq.connections import RedisSettings
 from watchfiles import awatch
 
-from prince_archiver.config import Settings, get_settings
+from prince_archiver.config import WatcherSettings
 from prince_archiver.db import UnitOfWork, get_session_maker
 from prince_archiver.logging import configure_logging
 from prince_archiver.watcher import (
@@ -17,11 +17,11 @@ from prince_archiver.watcher import (
 )
 
 
-async def main(*, _settings: Settings | None = None):
+async def main(*, _settings: WatcherSettings | None = None):
 
     configure_logging()
 
-    settings = _settings or get_settings()
+    settings = _settings or WatcherSettings()
 
     redis = await create_pool(
         RedisSettings.from_dsn(str(settings.REDIS_DSN)),

--- a/prince-archiver/prince_archiver/worker.py
+++ b/prince-archiver/prince_archiver/worker.py
@@ -14,7 +14,8 @@ import s3fs
 from aiofiles.tempfile import TemporaryDirectory
 from arq.connections import RedisSettings
 
-from .config import Settings, get_settings
+from .config import WorkerSettings as _WorkerSettings
+from .config import get_worker_settings
 from .dto import TimestepDTO
 from .logging import configure_logging
 
@@ -58,7 +59,7 @@ async def workflow(ctx: dict, input_data: dict):
 
     data = TimestepDTO.model_validate(input_data)
 
-    settings: Settings = ctx["settings"]
+    settings: _WorkerSettings = ctx["settings"]
     s3: s3fs.S3FileSystem = ctx["s3"]
     pool: ProcessPoolExecutor = ctx["pool"]
 
@@ -88,7 +89,7 @@ async def workflow(ctx: dict, input_data: dict):
 
 @asynccontextmanager
 async def managed_file_system(
-    settings: Settings,
+    settings: _WorkerSettings,
 ) -> AsyncGenerator[s3fs.S3FileSystem, None]:
     client_kwargs = {}
     if settings.AWS_REGION_NAME:
@@ -112,7 +113,7 @@ async def managed_file_system(
 async def startup(ctx):
     configure_logging()
 
-    settings = get_settings()
+    settings = get_worker_settings()
     ctx["settings"] = settings
 
     exit_stack = await AsyncExitStack().__aenter__()


### PR DESCRIPTION
## Description
AWS settings are not needed for the worker. Can simplify things by separating watcher and worker settings


## Implementation
- Introduce `WorkerSettings` and `WatcherSettings`