### PR TITLE
prince-archiver: Improve settings

### DIFF
--- a/prince-archiver/.gitignore
+++ b/prince-archiver/.gitignore
@@ -173,7 +173,8 @@ poetry.toml
 # LSP config files
 pyrightconfig.json
 
-
+.env*
+!.env.example
 .vscode
 scratch/
 

--- a/prince-archiver/alembic/env.py
+++ b/prince-archiver/alembic/env.py
@@ -32,7 +32,7 @@ target_metadata = Base.metadata
 def get_url() -> str:
     dsn = os.getenv(
         "POSTGRES_DSN",
-        "asyncpg+postsgresql://postgres:postgres@localhost:5432/postgres",
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/postgres",
     )
     return dsn
 

--- a/prince-archiver/alembic/versions/92facd817ef9_init.py
+++ b/prince-archiver/alembic/versions/92facd817ef9_init.py
@@ -1,8 +1,8 @@
 """Init
 
-Revision ID: 35ea6f897530
-Revises:
-Create Date: 2024-04-08 14:17:13.889684
+Revision ID: 92facd817ef9
+Revises: 
+Create Date: 2024-04-18 11:42:54.053106
 
 """
 
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "35ea6f897530"
+revision: str = "92facd817ef9"
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -28,8 +28,11 @@ def upgrade() -> None:
         sa.Column("archive_name", sa.String(), nullable=False),
         sa.Column("position", sa.Integer(), nullable=False),
         sa.Column("img_count", sa.Integer(), nullable=False),
-        sa.Column("timestamp", sa.DateTime(), nullable=False),
-        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("timestamp", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("src_dir", sa.String(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), nullable=False),
         sa.PrimaryKeyConstraint("timestep_id"),
     )
     # ### end Alembic commands ###

--- a/prince-archiver/compose.dev.yml
+++ b/prince-archiver/compose.dev.yml
@@ -25,6 +25,9 @@ services:
     volumes:
     - ./prince_archiver:/app/prince_archiver
     - ./alembic/:/app/alembic
+    depends_on:
+      s3:
+        condition: service_healthy
 
   s3:
     image: adobe/s3mock:3.1.0
@@ -34,3 +37,8 @@ services:
     environment:
       - initialBuckets=mycostreams
       - validKmsKeys=arn:aws:kms:eu-central-1:1234567890:key/aws-access-key-id
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/prince-archiver/compose.prod.yml
+++ b/prince-archiver/compose.prod.yml
@@ -5,14 +5,19 @@ services:
   watcher:
     environment:
       - SENTRY_DSN
+      - WATCHFILES_FORCE_POLLING=true
     labels:
       com.datadoghq.ad.logs: '[{"source": "watcher", "service": "watcher"}]'
+    env_file:
+      - .env.prod
   
   worker:
     environment:
       - SENTRY_DSN
     labels:
       com.datadoghq.ad.logs: '[{"source": "worker", "service": "worker"}]'
+    env_file:
+      - .env.prod
 
   datadog:
     image: datadog/agent:latest

--- a/prince-archiver/compose.prod.yml
+++ b/prince-archiver/compose.prod.yml
@@ -28,14 +28,10 @@ services:
      - /var/lib/docker/containers:/var/lib/docker/containers:ro
 
 
-# volumes:
-#   input_data: 
-#     driver_opts:
-#       type: cifs
-#       device: //prince.amolf.nl/Data/Prince2/Images/Data/Prince2/Images/
-#       o: username=${PRINCE_USERNAME},password=${PRINCE_PASSWORD}
-#   output_data: 
-#     driver_opts:
-#       type: cifs
-#       device: //sun.amolf.nl/shimizu/home-folder/iwilliams/test
-#       o: username=${SUN_USERNAME},password=${SUN_PASSWORD}
+volumes:
+  input_data: 
+    driver_opts:
+      type: cifs
+      device: //prince.amolf.nl/Data/Prince2/Images/
+      o: username=${AMOLF_USERNAME},password=${AMOLF_PASSWORD}
+

--- a/prince-archiver/compose.yml
+++ b/prince-archiver/compose.yml
@@ -3,6 +3,7 @@ version: "3.8"
 x-env-variables: &env-variables
   DATA_DIR: /data/input/
   REDIS_DSN: redis://redis:6379
+  POSTGRES_DSN: postgresql+asyncpg://postgres:postgres@db:5432/postgres
 
 
 services:
@@ -13,7 +14,6 @@ services:
       context: .
     environment: 
       <<: *env-variables
-      POSTGRES_DSN: postgresql+asyncpg://postgres:postgres@db:5432/postgres
     command: ["python", "-m", "prince_archiver.entrypoints.watcher"]
     volumes:
     - input_data:/data/input
@@ -30,6 +30,8 @@ services:
     volumes:
     - input_data:/data/input
     depends_on:
+      db:
+        condition: service_healthy
       redis:
         condition: service_healthy
 

--- a/prince-archiver/compose.yml
+++ b/prince-archiver/compose.yml
@@ -26,17 +26,12 @@ services:
   worker:
     image: prince-archiver
     command: ["arq", "prince_archiver.worker.WorkerSettings"]
-    environment: 
-      <<: *env-variables
-      ARCHIVE_DIR: /data/archive/
+    environment: *env-variables
     volumes:
     - input_data:/data/input
-    - archive_data:/data/archive
     depends_on:
       redis:
         condition: service_healthy
-    env_file:
-      - .env
 
   redis:
     image: redis:7.2.4
@@ -67,5 +62,4 @@ services:
 
 volumes:
   input_data:
-  archive_data:
   postgres_data:

--- a/prince-archiver/prince_archiver/config.py
+++ b/prince-archiver/prince_archiver/config.py
@@ -38,8 +38,6 @@ class WorkerSettings(CommonSettings):
     AWS_ENDPOINT_URL: str | None = None
     AWS_REGION_NAME: str | None = None
 
-    ARCHIVE_DIR: Path
-
 
 @lru_cache
 def get_worker_settings() -> WorkerSettings:

--- a/prince-archiver/prince_archiver/config.py
+++ b/prince-archiver/prince_archiver/config.py
@@ -29,6 +29,8 @@ class WatcherSettings(CommonSettings):
 
     POSTGRES_DSN: PostgresDsn
 
+    WATCHFILES_FORCE_POLLING: bool | None = None
+
 
 class WorkerSettings(CommonSettings):
 

--- a/prince-archiver/prince_archiver/config.py
+++ b/prince-archiver/prince_archiver/config.py
@@ -15,6 +15,7 @@ sentry_sdk.init(
 class CommonSettings(BaseSettings):
 
     REDIS_DSN: RedisDsn
+    POSTGRES_DSN: PostgresDsn
 
     DATA_DIR: Path
 
@@ -26,8 +27,6 @@ class CommonSettings(BaseSettings):
 
 
 class WatcherSettings(CommonSettings):
-
-    POSTGRES_DSN: PostgresDsn
 
     WATCHFILES_FORCE_POLLING: bool | None = None
 

--- a/prince-archiver/prince_archiver/db.py
+++ b/prince-archiver/prince_archiver/db.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
+from uuid import UUID
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from .models import Timestep
@@ -19,6 +21,9 @@ class AbstractTimestepRepo(ABC):
     @abstractmethod
     def add(self, timestep: Timestep) -> None: ...
 
+    @abstractmethod
+    async def get(self, id: UUID) -> Timestep | None: ...
+
 
 class TimestempRepo(AbstractTimestepRepo):
 
@@ -27,6 +32,11 @@ class TimestempRepo(AbstractTimestepRepo):
 
     def add(self, timestamp: Timestep) -> None:
         self.session.add(timestamp)
+
+    async def get(self, id: UUID) -> Timestep | None:
+        return await self.session.scalar(
+            select(Timestep).where(Timestep.timestep_id == id),
+        )
 
 
 class AbstractUnitOfWork(ABC):

--- a/prince-archiver/prince_archiver/dto.py
+++ b/prince-archiver/prince_archiver/dto.py
@@ -21,14 +21,13 @@ class TimestepMeta(BaseModel):
     cross_date: date
     position: int
     timestamp: datetime
+    img_count: int = 150
 
 
 class TimestepDTO(TimestepMeta):
 
     timestep_dir_name: str
     img_dir_name: str
-
-    img_count: int = 150
 
     experiment_id: str = Field(default_factory=str)
     archive_name: str = Field(default_factory=str)

--- a/prince-archiver/prince_archiver/dto.py
+++ b/prince-archiver/prince_archiver/dto.py
@@ -12,7 +12,6 @@ class DirectoryConfig:
 
     param_filename = "param.json"
     img_dir_name: str = "Img"
-    final_img_name: str = "Img_r10_c15.tif"
 
 
 class TimestepMeta(BaseModel):

--- a/prince-archiver/prince_archiver/entrypoints/cli.py
+++ b/prince-archiver/prince_archiver/entrypoints/cli.py
@@ -5,7 +5,9 @@ from typing import Annotated, Optional
 import typer
 
 from prince_archiver.dto import TimestepMeta
-from prince_archiver.utils import make_timestep_directory as _make_timestep_directory
+from prince_archiver.test_utils import (
+    make_timestep_directory as _make_timestep_directory,
+)
 
 app = typer.Typer()
 

--- a/prince-archiver/prince_archiver/entrypoints/timestep_generator.py
+++ b/prince-archiver/prince_archiver/entrypoints/timestep_generator.py
@@ -1,13 +1,22 @@
 import logging
 import os
 import time
-from datetime import date, datetime
+from datetime import date
 from pathlib import Path
 from uuid import uuid4
 
 from prince_archiver.dto import TimestepMeta
 from prince_archiver.logging import configure_logging
-from prince_archiver.utils import make_timestep_directory
+from prince_archiver.utils import make_timestep_directory, now
+
+
+def _create_meta() -> TimestepMeta:
+    return TimestepMeta(
+        plate=1,
+        cross_date=date(2000, 1, 1),
+        position=1,
+        timestamp=now(),
+    )
 
 
 def main():
@@ -16,18 +25,9 @@ def main():
 
     data_dir = Path(os.environ.get("DATA_DIR", "/app/data"))
 
-    meta = TimestepMeta(
-        plate=1,
-        cross_date=date(2000, 1, 1),
-        position=1,
-        timestamp=datetime.now(),
-    )
-
     while True:
-
         target_dir = data_dir / uuid4().hex[:6]
-
-        make_timestep_directory(target_dir, meta)
+        make_timestep_directory(target_dir, _create_meta())
 
         logging.info("Directory added: %s", target_dir)
 

--- a/prince-archiver/prince_archiver/entrypoints/timestep_generator.py
+++ b/prince-archiver/prince_archiver/entrypoints/timestep_generator.py
@@ -7,7 +7,8 @@ from uuid import uuid4
 
 from prince_archiver.dto import TimestepMeta
 from prince_archiver.logging import configure_logging
-from prince_archiver.utils import make_timestep_directory, now
+from prince_archiver.test_utils import make_timestep_directory
+from prince_archiver.utils import now
 
 
 def _create_meta() -> TimestepMeta:

--- a/prince-archiver/prince_archiver/entrypoints/watcher.py
+++ b/prince-archiver/prince_archiver/entrypoints/watcher.py
@@ -13,7 +13,7 @@ from prince_archiver.watcher import (
     ArqHandler,
     TimestepHandler,
     add_to_db,
-    filter_on_final_image,
+    filter_on_param_file,
 )
 
 
@@ -36,10 +36,14 @@ async def main(*, _settings: WatcherSettings | None = None):
 
     logging.info("Watching %s", settings.DATA_DIR)
 
-    watcher = awatch(settings.DATA_DIR, watch_filter=filter_on_final_image)
+    watcher = awatch(
+        settings.DATA_DIR,
+        watch_filter=filter_on_param_file,
+        force_polling=settings.WATCHFILES_FORCE_POLLING,
+    )
     async for changes in watcher:
         for _, filepath in changes:
-            await handler(Path(filepath).parent.parent)
+            await handler(Path(filepath).parent)
 
 
 if __name__ == "__main__":

--- a/prince-archiver/prince_archiver/file.py
+++ b/prince-archiver/prince_archiver/file.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+import tarfile
+from concurrent.futures import Executor
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncGenerator
+
+import cv2
+import s3fs
+
+from .config import WorkerSettings
+
+LOGGER = logging.getLogger(__name__)
+
+
+def compress(src: Path, target: Path):
+    LOGGER.info("Compressing %s", src)
+
+    img = cv2.imread(str(src))
+    cv2.imwrite(
+        str(target),
+        img,
+        params=(cv2.IMWRITE_TIFF_COMPRESSION, 5),
+    )
+
+    LOGGER.info("Compressed %s", src)
+
+
+async def acompress(src: Path, target: Path, executor: Executor):
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(executor, compress, src, target)
+
+
+def tar(src: Path, target: Path):
+    LOGGER.info("Tarring %s", src)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(target, "a") as tar:
+        tar.add(src, arcname=".")
+
+    LOGGER.info("Tarred %s", src)
+
+
+async def atar(src: Path, target: Path, executor: Executor):
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(executor, tar, src, target)
+
+
+@asynccontextmanager
+async def managed_file_system(
+    settings: WorkerSettings,
+) -> AsyncGenerator[s3fs.S3FileSystem, None]:
+    client_kwargs = {}
+    if settings.AWS_REGION_NAME:
+        client_kwargs["region_name"] = settings.AWS_REGION_NAME
+
+    s3 = s3fs.S3FileSystem(
+        key=settings.AWS_ACCESS_KEY_ID,
+        secret=settings.AWS_SECRET_ACCESS_KEY,
+        endpoint_url=settings.AWS_ENDPOINT_URL,
+        client_kwargs=client_kwargs,
+        asynchronous=True,
+    )
+
+    session = await s3.set_session()
+
+    yield s3
+
+    await session.close()

--- a/prince-archiver/prince_archiver/models.py
+++ b/prince-archiver/prince_archiver/models.py
@@ -2,11 +2,16 @@ from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from sqlalchemy.types import Uuid
+from sqlalchemy.types import TIMESTAMP, Uuid
+
+from .utils import now
 
 
 class Base(DeclarativeBase):
-    pass
+
+    type_annotation_map = {
+        datetime: TIMESTAMP(timezone=True),
+    }
 
 
 class Timestep(Base):
@@ -19,5 +24,8 @@ class Timestep(Base):
     position: Mapped[int]
     img_count: Mapped[int]
     timestamp: Mapped[datetime]
+    src_dir: Mapped[str]
+    is_active: Mapped[bool | None] = mapped_column(default=None)
 
-    created_at: Mapped[datetime] = mapped_column(default=datetime.now)
+    created_at: Mapped[datetime] = mapped_column(default=now)
+    updated_at: Mapped[datetime] = mapped_column(default=now, onupdate=now)

--- a/prince-archiver/prince_archiver/test_utils.py
+++ b/prince-archiver/prince_archiver/test_utils.py
@@ -1,0 +1,32 @@
+from functools import lru_cache
+from pathlib import Path
+
+import httpx
+
+from .dto import DirectoryConfig, TimestepMeta
+
+DOWNLOAD_URL = "https://vu.data.surfsara.nl/index.php/s/ndI1UoMRwliVYGR/download"
+
+
+@lru_cache
+def _get_image(url: str = DOWNLOAD_URL):
+    response = httpx.get(url)
+    return response.content
+
+
+def make_timestep_directory(
+    target_dir: Path,
+    meta: TimestepMeta,
+    config: DirectoryConfig | None = None,
+) -> None:
+    """Construct a new timestep directory."""
+    config = config or DirectoryConfig()
+
+    img_dir = target_dir / config.img_dir_name
+    img_dir.mkdir(parents=True, exist_ok=True)
+
+    img = img_dir / "Img_r10_c15.tif"
+    img.write_bytes(_get_image())
+
+    param_file = target_dir / config.param_filename
+    param_file.write_text(meta.model_dump_json(indent=4, by_alias=True))

--- a/prince-archiver/prince_archiver/utils.py
+++ b/prince-archiver/prince_archiver/utils.py
@@ -1,13 +1,9 @@
 from datetime import UTC, datetime
-from functools import lru_cache, partial
+from functools import partial
 from pathlib import Path
 from typing import Generator
 
-import httpx
-
 from .dto import DirectoryConfig, TimestepDTO, TimestepMeta
-
-DOWNLOAD_URL = "https://vu.data.surfsara.nl/index.php/s/ndI1UoMRwliVYGR/download"
 
 
 def now() -> datetime:
@@ -45,27 +41,3 @@ def get_plate_timesteps(
 
     for item in map(func, data_dir.iterdir()):
         yield item
-
-
-@lru_cache
-def _get_image(url: str = DOWNLOAD_URL):
-    response = httpx.get(url)
-    return response.content
-
-
-def make_timestep_directory(
-    target_dir: Path,
-    meta: TimestepMeta,
-    config: DirectoryConfig | None = None,
-) -> None:
-    """Construct a new timestep directory."""
-    config = config or DirectoryConfig()
-
-    img_dir = target_dir / config.img_dir_name
-    img_dir.mkdir(parents=True, exist_ok=True)
-
-    img = img_dir / "Img_r10_c15.tif"
-    img.write_bytes(_get_image())
-
-    param_file = target_dir / config.param_filename
-    param_file.write_text(meta.model_dump_json(indent=4, by_alias=True))

--- a/prince-archiver/prince_archiver/utils.py
+++ b/prince-archiver/prince_archiver/utils.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from functools import lru_cache, partial
 from pathlib import Path
 from typing import Generator
@@ -7,6 +8,10 @@ import httpx
 from .dto import DirectoryConfig, TimestepDTO, TimestepMeta
 
 DOWNLOAD_URL = "https://vu.data.surfsara.nl/index.php/s/ndI1UoMRwliVYGR/download"
+
+
+def now() -> datetime:
+    return datetime.now(UTC)
 
 
 def parse_timestep_dir(

--- a/prince-archiver/prince_archiver/utils.py
+++ b/prince-archiver/prince_archiver/utils.py
@@ -59,8 +59,8 @@ def make_timestep_directory(
     img_dir = target_dir / config.img_dir_name
     img_dir.mkdir(parents=True, exist_ok=True)
 
+    img = img_dir / "Img_r10_c15.tif"
+    img.write_bytes(_get_image())
+
     param_file = target_dir / config.param_filename
     param_file.write_text(meta.model_dump_json(indent=4, by_alias=True))
-
-    img = img_dir / config.final_img_name
-    img.write_bytes(_get_image())

--- a/prince-archiver/prince_archiver/watcher.py
+++ b/prince-archiver/prince_archiver/watcher.py
@@ -16,8 +16,8 @@ LOGGER = logging.getLogger(__name__)
 HandlerT = Callable[[TimestepDTO, AbstractUnitOfWork], Awaitable[None]]
 
 
-def filter_on_final_image(change: Change, path: str) -> bool:
-    return change == Change.added and Path(path).name == "Img_r10_c15.tif"
+def filter_on_param_file(change: Change, path: str) -> bool:
+    return change == Change.added and Path(path).name == "param.json"
 
 
 class TimestepHandler:

--- a/prince-archiver/prince_archiver/watcher.py
+++ b/prince-archiver/prince_archiver/watcher.py
@@ -45,6 +45,7 @@ async def add_to_db(data: TimestepDTO, unit_of_work: AbstractUnitOfWork) -> None
 
     async with unit_of_work:
         timestep = Timestep(
+            src_dir=data.timestep_dir_name,
             **data.model_dump(
                 exclude={
                     "timestep_dir_name",

--- a/prince-archiver/prince_archiver/worker.py
+++ b/prince-archiver/prince_archiver/worker.py
@@ -1,15 +1,12 @@
 import asyncio
 import logging
 import os
-import tarfile
-from concurrent.futures import Executor, ProcessPoolExecutor
-from contextlib import AsyncExitStack, asynccontextmanager
+from concurrent.futures import ProcessPoolExecutor
+from contextlib import AsyncExitStack
 from pathlib import Path
-from typing import AsyncGenerator
 
 import aiofiles
 import aiofiles.os
-import cv2
 import s3fs
 from aiofiles.tempfile import TemporaryDirectory
 from arq.connections import RedisSettings
@@ -17,42 +14,10 @@ from arq.connections import RedisSettings
 from .config import WorkerSettings as _WorkerSettings
 from .config import get_worker_settings
 from .dto import TimestepDTO
+from .file import acompress, atar, managed_file_system
 from .logging import configure_logging
 
 LOGGER = logging.getLogger(__name__)
-
-
-def compress(src: Path, target: Path):
-    LOGGER.info("Compressing %s", src)
-
-    img = cv2.imread(str(src))
-    cv2.imwrite(
-        str(target),
-        img,
-        params=(cv2.IMWRITE_TIFF_COMPRESSION, 5),
-    )
-
-    LOGGER.info("Compressed %s", src)
-
-
-async def acompress(src: Path, target: Path, executor: Executor):
-    loop = asyncio.get_event_loop()
-    await loop.run_in_executor(executor, compress, src, target)
-
-
-def tar(src: Path, target: Path):
-    LOGGER.info("Tarring %s", src)
-
-    target.parent.mkdir(parents=True, exist_ok=True)
-    with tarfile.open(target, "a") as tar:
-        tar.add(src, arcname=".")
-
-    LOGGER.info("Tarred %s", src)
-
-
-async def atar(src: Path, target: Path, executor: Executor):
-    loop = asyncio.get_event_loop()
-    await loop.run_in_executor(executor, tar, src, target)
 
 
 async def workflow(ctx: dict, input_data: dict):
@@ -79,29 +44,6 @@ async def workflow(ctx: dict, input_data: dict):
         await atar(temp_img_dir, temp_archive_path, pool)
 
         await s3._put_file(temp_archive_path, f"{settings.AWS_BUCKET_NAME}/{data.key}")
-
-
-@asynccontextmanager
-async def managed_file_system(
-    settings: _WorkerSettings,
-) -> AsyncGenerator[s3fs.S3FileSystem, None]:
-    client_kwargs = {}
-    if settings.AWS_REGION_NAME:
-        client_kwargs["region_name"] = settings.AWS_REGION_NAME
-
-    s3 = s3fs.S3FileSystem(
-        key=settings.AWS_ACCESS_KEY_ID,
-        secret=settings.AWS_SECRET_ACCESS_KEY,
-        endpoint_url=settings.AWS_ENDPOINT_URL,
-        client_kwargs=client_kwargs,
-        asynchronous=True,
-    )
-
-    session = await s3.set_session()
-
-    yield s3
-
-    await session.close()
 
 
 async def startup(ctx):

--- a/prince-archiver/prince_archiver/worker.py
+++ b/prince-archiver/prince_archiver/worker.py
@@ -58,6 +58,10 @@ async def workflow(
     uow: AbstractUnitOfWork = ctx["uow"]
     async with uow:
         await upload_workflow(ctx, data)
+
+        if timestep := await uow.timestamps.get(id=data.timestep_id):
+            timestep.is_active = True
+
         await uow.commit()
 
 
@@ -76,7 +80,7 @@ async def startup(ctx):
     ctx["sessionmaker"] = get_session_maker(str(settings.POSTGRES_DSN))
 
 
-async def on_job_start(ctx):
+async def on_job_start(ctx: dict):
     session_maker: async_sessionmaker[AsyncSession] = ctx["sessionmaker"]
     ctx["uow"] = UnitOfWork(session_maker)
 


### PR DESCRIPTION
## Description
 Improve separation of settings between `worker` and `watcher`. Update db schema.

## Implementation
- Add `.get` method to repo
- Listen for addition of `param.json` file, not the last image file
- Uncomment prod volumes in docker compose
- `on_job_start` hook used to instantiate a unit of work.
- Prod watcher needs to rely on polling, therefore add `WATCHFILES_FORCE_POLLING` settings
- Group test utils in own file