### PR TITLE
prince-archiver: Bugfixes

### DIFF
--- a/prince-archiver/prince_archiver/data_archive/handlers.py
+++ b/prince-archiver/prince_archiver/data_archive/handlers.py
@@ -90,7 +90,7 @@ class DeletedExpiredUploadsHandler(AbstractHandler[DeleteExpiredUploads]):
 
             expiring_timestamps = filter(
                 partial(self._is_deletable, job_id=message.job_id),
-                await uow.timestamps.get_by_upload_date(message.uploaded_on),
+                await uow.timestamps.get_by_date(message.uploaded_on),
             )
 
             remote_paths: list[str] = []

--- a/prince-archiver/prince_archiver/db.py
+++ b/prince-archiver/prince_archiver/db.py
@@ -31,9 +31,6 @@ class AbstractTimestepRepo(ABC):
     @abstractmethod
     async def get_by_date(self, date_: date) -> list[Timestep]: ...
 
-    @abstractmethod
-    async def get_by_upload_date(self, date_: date) -> list[Timestep]: ...
-
 
 class TimestepRepo(AbstractTimestepRepo):
     def __init__(self, session: AsyncSession):
@@ -51,14 +48,6 @@ class TimestepRepo(AbstractTimestepRepo):
     async def get_by_date(self, date_: date) -> list[Timestep]:
         result = await self.session.scalars(
             self._base_query().where(func.date(Timestep.timestamp) == date_),
-        )
-        return list(result.all())
-
-    async def get_by_upload_date(self, date_: date) -> list[Timestep]:
-        result = await self.session.scalars(
-            self._base_query()
-            .join(Timestep.object_store_entry)
-            .where(func.date(ObjectStoreEntry.created_at) == date_)
         )
         return list(result.all())
 

--- a/prince-archiver/prince_archiver/dto.py
+++ b/prince-archiver/prince_archiver/dto.py
@@ -1,10 +1,10 @@
 """Definition of data transfer objects."""
 
-from datetime import date, UTC
+from datetime import UTC, date
 from pathlib import Path
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, AwareDatetime, Field, model_validator
+from pydantic import AwareDatetime, BaseModel, Field, model_validator
 
 
 class TimestepMeta(BaseModel):

--- a/prince-archiver/prince_archiver/dto.py
+++ b/prince-archiver/prince_archiver/dto.py
@@ -1,10 +1,10 @@
 """Definition of data transfer objects."""
 
-from datetime import date, datetime
+from datetime import date, UTC
 from pathlib import Path
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, AwareDatetime, Field, model_validator
 
 
 class TimestepMeta(BaseModel):
@@ -13,7 +13,7 @@ class TimestepMeta(BaseModel):
     cross_date: date
     experiment_id: str = Field(default_factory=str)
     position: int
-    timestamp: datetime
+    timestamp: AwareDatetime
     img_count: int = Field(150, alias="image_count")
     img_dir: Path = Field(..., alias="path")
 
@@ -31,6 +31,7 @@ class TimestepDTO(TimestepMeta):
     @model_validator(mode="after")
     def set_key(self) -> "TimestepDTO":
         if not self.key:
-            root = self.timestamp.strftime("%Y%m%d_%H%M.tar")
+            ts = self.timestamp.astimezone(UTC)
+            root = ts.strftime("%Y%m%d_%H%M.tar")
             self.key = f"{self.experiment_id}/{root}"
         return self

--- a/prince-archiver/prince_archiver/upload_worker/handlers.py
+++ b/prince-archiver/prince_archiver/upload_worker/handlers.py
@@ -24,7 +24,11 @@ _T = TypeVar("_T")
 
 
 class UploadHandler(AbstractHandler[UploadDTO]):
-    def __init__(self, s3: s3fs.S3FileSystem, pool: Executor):
+    def __init__(
+        self,
+        s3: s3fs.S3FileSystem,
+        pool: Executor,
+    ):
         self.s3 = s3
         self.pool = pool
 

--- a/prince-archiver/tests/integration/test_repository.py
+++ b/prince-archiver/tests/integration/test_repository.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import date, datetime, UTC
 from uuid import UUID, uuid4
 
 import pytest
@@ -17,12 +17,12 @@ async def fixture_timestep() -> Timestep:
         experiment_id="test-experiment-id",
         position=1,
         img_count=150,
-        timestamp=datetime(2000, 1, 1, tzinfo=timezone.utc),
+        timestamp=datetime(2000, 1, 1, tzinfo=UTC),
         local_dir=None,
         object_store_entry=ObjectStoreEntry(
             key="test-key",
             bucket="test-bucket",
-            created_at=datetime(2010, 1, 1, tzinfo=timezone.utc),
+            created_at=datetime(2010, 1, 1, tzinfo=UTC),
         ),
     )
 
@@ -52,12 +52,3 @@ async def test_get_by_id(repo: TimestepRepo):
     # Valid id
     timestep = await repo.get(UUID("8d2b1f49f5af4b6b853173e9ae9ef3b3"))
     assert timestep
-
-
-async def test_get_by_upload_date(repo: TimestepRepo):
-    # Invalid
-    assert not await repo.get_by_upload_date(date.today())
-
-    # Valid
-    timesteps = await repo.get_by_upload_date(date(2010, 1, 1))
-    assert len(timesteps) == 1

--- a/prince-archiver/tests/integration/test_repository.py
+++ b/prince-archiver/tests/integration/test_repository.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, UTC
+from datetime import UTC, date, datetime
 from uuid import UUID, uuid4
 
 import pytest

--- a/prince-archiver/tests/unit/data_archive/test_handlers.py
+++ b/prince-archiver/tests/unit/data_archive/test_handlers.py
@@ -76,7 +76,7 @@ async def test_delete_expired_uploads_handler(
     handler = DeletedExpiredUploadsHandler(mock_s3)
 
     repo = AsyncMock(AbstractTimestepRepo)
-    repo.get_by_upload_date.return_value = [archived_timestep, unarchived_timestep]
+    repo.get_by_date.return_value = [archived_timestep, unarchived_timestep]
     uow = AsyncMock(AbstractUnitOfWork, timestamps=repo)
 
     message = DeleteExpiredUploads(job_id=uuid4(), uploaded_on=date(2000, 1, 1))


### PR DESCRIPTION
## Description
Fix mismatch in date between database time and stored key.


## Implementation
- Date stored in key in local time. Ensure that it is in UTC. Done in DTO.
- `get_by_upload_date` redundant, use `get_by_date` instead. Remove references and tests.
- Import `datetime.UTC` instead of `datetime.timezone.utc`
