### PR TITLE
prince-archiver: Move archive subscriber into worker

### DIFF
--- a/prince-archiver/compose.dev.yml
+++ b/prince-archiver/compose.dev.yml
@@ -55,7 +55,7 @@ services:
       - ./alembic/:/app/alembic
 
   s3:
-    image: adobe/s3mock:3.1.0
+    image: adobe/s3mock:3.10.0
     ports:
       - 9090:9090
       - 9191:9191

--- a/prince-archiver/compose.dev.yml
+++ b/prince-archiver/compose.dev.yml
@@ -37,6 +37,7 @@ services:
   cron-worker:
     environment:
       <<: *aws-env-variables
+      RABBITMQ_DSN: amqp://guest:guest@rabbitmq:5672
       SURF_USERNAME: ""
       SURF_PASSWORD: ""
     volumes:
@@ -45,14 +46,6 @@ services:
     depends_on:
       s3:
         condition: service_healthy
-
-  data-archive-subscriber:
-    environment:
-      RABBITMQ_DSN: amqp://guest:guest@rabbitmq:5672
-    volumes:
-      - ./prince_archiver:/app/prince_archiver
-      - ./alembic/:/app/alembic
-    depends_on:
       rabbitmq:
         condition: service_healthy
   

--- a/prince-archiver/compose.prod.yml
+++ b/prince-archiver/compose.prod.yml
@@ -39,21 +39,12 @@ services:
   cron-worker:
     environment:
       <<: *aws-env-variables
-      SURF_USERNAME: ${SURF_USERNAME}
-      SURF_PASSWORD: ${SURF_PASSWORD}
-      SENTRY_DSN: ${SENTRY_DSN}
-      UPLOAD_EXPIRY_DAYS: ${UPLOAD_EXPIRY_DAYS:-5}
       ARCHIVE_TRANSITION_DAYS: ${ARCHIVE_TRANSITION_DAYS:-2}
-      WEBHOOK_URL: ${WEBHOOK_URL}
-    labels: *log-labels
-    deploy:
-      restart_policy:
-        condition: on-failure
-
-  data-archive-subscriber:
-    environment:
       SENTRY_DSN: ${SENTRY_DSN}
       RABBITMQ_DSN: ${RABBITMQ_DSN}
+      SURF_USERNAME: ${SURF_USERNAME}
+      SURF_PASSWORD: ${SURF_PASSWORD}
+      WEBHOOK_URL: ${WEBHOOK_URL}
     labels: *log-labels
     deploy:
       restart_policy:

--- a/prince-archiver/compose.yml
+++ b/prince-archiver/compose.yml
@@ -43,15 +43,6 @@ services:
       redis:
         condition: service_healthy
 
-  data-archive-subscriber:
-    image: prince-archiver
-    command: ["python", "-m", "prince_archiver.data_archive.subscriber"]
-    environment:
-      POSTGRES_DSN: postgresql+asyncpg://postgres:postgres@db:5432/postgres
-    depends_on:
-      db:
-        condition: service_healthy
-
   db-migrations:
     image: prince-archiver
     command: ["alembic", "upgrade", "head"]

--- a/prince-archiver/prince_archiver/config.py
+++ b/prince-archiver/prince_archiver/config.py
@@ -57,6 +57,8 @@ class WorkerSettings(AWSSettings, CommonSettings):
 
 
 class ArchiveWorkerSettings(AWSSettings, CommonSettings):
+    RABBITMQ_DSN: str
+
     SURF_USERNAME: str
     SURF_PASSWORD: str
 
@@ -64,19 +66,7 @@ class ArchiveWorkerSettings(AWSSettings, CommonSettings):
 
     WEBHOOK_URL: HttpUrl | None = None
 
-    UPLOAD_EXPIRY_DAYS: int = 5
     ARCHIVE_TRANSITION_DAYS: int = 2
-
-
-class SubscriberSettings(BaseSettings):
-    POSTGRES_DSN: PostgresDsn
-    RABBITMQ_DSN: str
-
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-        extra="ignore",
-    )
 
 
 @lru_cache

--- a/prince-archiver/prince_archiver/data_archive/subscriber.py
+++ b/prince-archiver/prince_archiver/data_archive/subscriber.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
@@ -6,14 +5,6 @@ from typing import Awaitable, Callable
 
 from aio_pika import ExchangeType, connect_robust
 from aio_pika.abc import AbstractIncomingMessage
-
-from prince_archiver.config import SubscriberSettings
-from prince_archiver.db import UnitOfWork, get_session_maker
-from prince_archiver.logging import configure_logging
-from prince_archiver.messagebus import MessageBus
-
-from .dto import UpdateArchiveEntries
-from .handlers import SubscriberMessageHandler, add_data_archive_entries
 
 LOGGER = logging.getLogger(__name__)
 
@@ -55,34 +46,10 @@ class ManagedSubscriber:
         await queue.bind(exchange)
         await queue.consume(self.message_handler)
 
+        LOGGER.info("Subscribed to channel")
+
         return self
 
-    async def __aexit__(self, *_):
+    async def __aexit__(self, exc_type, exc_value, exc_tb):
         if self.exit_stack:
             await self.exit_stack.aclose()
-
-
-async def main(*, _settings: SubscriberSettings | None = None):
-    configure_logging()
-
-    settings = _settings or SubscriberSettings()
-
-    sessionmaker = get_session_maker(str(settings.POSTGRES_DSN))
-
-    def _messagebus_factory() -> MessageBus:
-        return MessageBus(
-            handlers={UpdateArchiveEntries: [add_data_archive_entries]},
-            uow=UnitOfWork(sessionmaker),
-        )
-
-    subscriber = ManagedSubscriber(
-        connection_url=settings.RABBITMQ_DSN,
-        message_handler=SubscriberMessageHandler(_messagebus_factory),
-    )
-    async with subscriber:
-        logging.info("Starting up")
-        await asyncio.Future()
-
-
-if __name__ == "__main__":
-    asyncio.run(main())

--- a/prince-archiver/prince_archiver/data_archive/worker.py
+++ b/prince-archiver/prince_archiver/data_archive/worker.py
@@ -4,6 +4,7 @@ from contextlib import AsyncExitStack
 from datetime import date, timedelta
 from functools import partial
 from typing import Callable
+from uuid import UUID, uuid4
 
 from arq import cron
 from arq.connections import RedisSettings
@@ -28,8 +29,13 @@ from .subscriber import ManagedSubscriber
 LOGGER = logging.getLogger(__name__)
 
 
-async def run_archiving(ctx: dict, *, _date: date | None = None):
-    job_id = ctx["internal_job_id"]
+async def run_archiving(
+    ctx: dict,
+    *,
+    _date: date | None = None,
+    _job_id: UUID | None = None,
+):
+    job_id = _job_id or uuid4()
     settings: ArchiveWorkerSettings = ctx["settings"]
     archiver: AbstractArchiver | None = ctx["archiver"]
 

--- a/prince-archiver/prince_archiver/upload_worker/handlers.py
+++ b/prince-archiver/prince_archiver/upload_worker/handlers.py
@@ -23,7 +23,7 @@ class UploadHandler(AbstractHandler[UploadDTO]):
     def __init__(
         self,
         s3: s3fs.S3FileSystem,
-        pool: Executor,
+        pool: Executor | None = None,
     ):
         self.s3 = s3
         self.pool = pool
@@ -34,7 +34,7 @@ class UploadHandler(AbstractHandler[UploadDTO]):
             self.get_temp_archive(message) as temp_archive_path,
         ):
             LOGGER.info("Uploading %s", message.key)
-            (await self.s3._put_file(temp_archive_path, message.key),)
+            await self.s3._put_file(temp_archive_path, message.key)
             await uow.commit()
 
     @asynccontextmanager

--- a/prince-archiver/prince_archiver/upload_worker/worker.py
+++ b/prince-archiver/prince_archiver/upload_worker/worker.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import AsyncExitStack
 
 from arq.connections import RedisSettings
@@ -47,14 +46,14 @@ async def startup(ctx):
     exit_stack = await AsyncExitStack().__aenter__()
 
     settings = get_worker_settings()
-    pool = exit_stack.enter_context(ThreadPoolExecutor())
+
     s3 = await exit_stack.enter_async_context(managed_file_system(settings))
     sessionmaker = get_session_maker(str(settings.POSTGRES_DSN))
 
     def _message_bus_factory():
         return MessageBus(
             handlers={
-                UploadDTO: [UploadHandler(s3=s3, pool=pool), add_upload_to_db],
+                UploadDTO: [UploadHandler(s3=s3), add_upload_to_db],
             },
             uow=UnitOfWork(sessionmaker),
         )


### PR DESCRIPTION
## Description
Move archive subscriber into worker


## Implementation
- Instantiate archive subscriber in `on_start_up` call of data archive worker adding to exit stack
- Remove definition of `data-archive-subscriber` from docker compose files
- Remove missing reference to `internal_job_id` introduced in `07dcaca`, pass in `job_id` instead