### PR TITLE
prince-archvier: Add archive file manager

### DIFF
--- a/prince-archiver/prince_archiver/adapters/file.py
+++ b/prince-archiver/prince_archiver/adapters/file.py
@@ -1,0 +1,119 @@
+import asyncio
+import logging
+import tarfile
+from concurrent.futures import Executor
+from contextlib import asynccontextmanager
+from hashlib import sha256
+from pathlib import Path
+from typing import AsyncGenerator, Awaitable, Callable, Protocol
+from uuid import uuid4
+
+import aiofiles.os
+from aiofiles.tempfile import TemporaryDirectory
+
+from prince_archiver.domain.value_objects import Algorithm, Checksum
+
+LOGGER = logging.getLogger(__name__)
+
+
+ChecksumFactoryT = Callable[[Path], Awaitable[Checksum]]
+
+
+class SrcPath(Path):
+    """
+    Path representing unarchived source image directory.
+    """
+
+
+class ArchivePath(Path):
+    """
+    Path representing archive file.
+    """
+
+
+class _HashProtocol(Protocol):
+    def update(self, data: bytes): ...
+
+    def hexdigest(self) -> str: ...
+
+
+class _ChecksumFactory:
+    """
+    Class for generating checksums.
+    """
+
+    DEFAULT_CHUNK_SIZE = 10 * 1024
+
+    HASH_MAPPING: dict[Algorithm, Callable[[], _HashProtocol]] = {
+        Algorithm.SHA256: sha256,
+    }
+
+    @classmethod
+    async def get_checksum(
+        cls,
+        path: Path,
+        *,
+        algorithm: Algorithm = Algorithm.SHA256,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+    ) -> Checksum:
+        hash = cls.HASH_MAPPING[algorithm]()
+        async with aiofiles.open(path, "rb") as file:
+            while chunk := await file.read(chunk_size):
+                hash.update(chunk)
+
+        return Checksum(
+            algorithm=algorithm,
+            hex=hash.hexdigest(),
+        )
+
+
+class ArchiveFileManager:
+    """
+    Class for managing archive files.
+    """
+
+    def __init__(
+        self,
+        *,
+        executor: Executor | None = None,
+        checksum_factory: ChecksumFactoryT = _ChecksumFactory.get_checksum,
+    ):
+        self.executor = executor
+        self.checksum_factory = checksum_factory
+
+    async def get_file_count(self, src_path: SrcPath) -> int:
+        files = await aiofiles.os.listdir(src_path, executor=self.executor)
+        return len(files)
+
+    async def get_archive_size(self, archive_path: ArchivePath) -> int:
+        stat = await aiofiles.os.stat(archive_path, executor=self.executor)
+        return stat.st_size
+
+    async def get_archive_checksum(self, archive_path: ArchivePath) -> Checksum:
+        return await self.checksum_factory(archive_path)
+
+    @asynccontextmanager
+    async def get_temp_archive(
+        self,
+        src_path: SrcPath,
+    ) -> AsyncGenerator[ArchivePath, None]:
+        async with TemporaryDirectory() as temp_dir:
+            temp_archive_path = ArchivePath(temp_dir, f"{uuid4().hex[:6]}.tar")
+
+            await self._tar_img_folder(src_path, temp_archive_path)
+
+            yield ArchivePath(temp_archive_path)
+
+    async def _tar_img_folder(self, src_dir: Path, target_path: Path):
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(self.executor, self._tar, src_dir, target_path)
+
+    @staticmethod
+    def _tar(src: Path, target: Path):
+        LOGGER.debug("Tarring %s", src)
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(target, "a") as tar:
+            tar.add(src, arcname=".")
+
+        LOGGER.debug("Tarred %s", src)

--- a/prince-archiver/tests/integration/test_archive_file_manager.py
+++ b/prince-archiver/tests/integration/test_archive_file_manager.py
@@ -1,0 +1,86 @@
+import tarfile
+from hashlib import sha256
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from prince_archiver.adapters.file import (
+    ArchiveFileManager,
+    ArchivePath,
+    SrcPath,
+)
+from prince_archiver.definitions import Algorithm
+from prince_archiver.domain.value_objects import Checksum
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(name="archive_file_manager")
+def fixture_archive_file_manager() -> ArchiveFileManager:
+    return ArchiveFileManager()
+
+
+@pytest.fixture(name="src_dir")
+def fixture_src_dir(tmp_path: Path):
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+
+    (src_dir / "test.txt").touch()
+
+    return SrcPath(src_dir)
+
+
+@pytest.fixture(name="temp_file")
+def fixture_temp_file(tmp_path: Path) -> Path:
+    return tmp_path / uuid4().hex[:6]
+
+
+async def test_file_count(
+    archive_file_manager: ArchiveFileManager,
+    src_dir: SrcPath,
+):
+    file_count = await archive_file_manager.get_file_count(src_dir)
+    assert file_count == 1
+
+
+async def test_get_temp_archive(
+    archive_file_manager: ArchiveFileManager,
+    src_dir: SrcPath,
+):
+    async with archive_file_manager.get_temp_archive(src_dir) as temp_archive:
+        assert temp_archive.exists()
+
+        with tarfile.open(temp_archive, "r") as tar:
+            assert set(tar.getnames()) == {".", "./test.txt"}
+
+    # check that it has been deleted
+    assert not temp_archive.exists()
+
+
+async def test_get_checksum(
+    archive_file_manager: ArchiveFileManager,
+    temp_file: Path,
+):
+    contents = b"123"
+    temp_file.write_bytes(contents)
+
+    checksum = await archive_file_manager.get_archive_checksum(ArchivePath(temp_file))
+
+    expected = Checksum(
+        algorithm=Algorithm.SHA256,
+        hex=sha256(contents).hexdigest(),
+    )
+
+    assert checksum == expected
+
+
+async def test_get_size(
+    archive_file_manager: ArchiveFileManager,
+    temp_file: Path,
+):
+    temp_file.write_bytes(b"123")
+
+    size = await archive_file_manager.get_archive_size(ArchivePath(temp_file))
+
+    assert size == temp_file.stat().st_size


### PR DESCRIPTION
## Description
Add `ArchiveFileManager` adapter class. This class is targeted at creating archive files.


## Implementation
- `ArchiveFileManager` has following public methods:
    -  `get_file_count` for counting files in src dir
    - `get_archive_checksum` for calculating checksum of archive file
    - `get_archive_size` for determining archive size in bytes
    - `get_temp_archive` for generating a temp archive from src dir.
- Add integrations tests
