### PR TITLE
prince-archiver: move uow into service layer

### DIFF
--- a/prince-archiver/prince_archiver/adapters/repository.py
+++ b/prince-archiver/prince_archiver/adapters/repository.py
@@ -1,27 +1,15 @@
 from abc import ABC, abstractmethod
 from datetime import date
-from typing import Generator
 from uuid import UUID
 
-from pydantic import BaseModel
 from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql import Select
 
 from prince_archiver.domain.models import ImagingEvent, StitchEvent, VideoEvent
-
-from .models import Timestep
-from .models import v2 as data_models
-
-
-def get_session_maker(url: str) -> async_sessionmaker[AsyncSession]:
-    engine = create_async_engine(url)
-    return async_sessionmaker(
-        autocommit=False,
-        autoflush=False,
-        bind=engine,
-    )
+from prince_archiver.models import Timestep
+from prince_archiver.models import v2 as data_models
 
 
 class AbstractImagingEventRepo(ABC):
@@ -97,63 +85,3 @@ class TimestepRepo(AbstractTimestepRepo):
             joinedload(Timestep.data_archive_entry),
             joinedload(Timestep.object_store_entry),
         )
-
-
-class AbstractUnitOfWork(ABC):
-    messages: list[BaseModel]
-
-    timestamps: AbstractTimestepRepo
-    imaging_events: AbstractImagingEventRepo
-
-    @abstractmethod
-    async def __aenter__(self) -> "AbstractUnitOfWork": ...
-
-    @abstractmethod
-    async def __aexit__(self, exc_type, exc_value, exc_traceback):
-        await self.rollback()
-
-    @abstractmethod
-    async def rollback(self) -> None: ...
-
-    @abstractmethod
-    async def commit(self) -> None: ...
-
-    @abstractmethod
-    def add_message(self, message: BaseModel): ...
-
-    @abstractmethod
-    def collect_messages(self) -> Generator[BaseModel, None, None]: ...
-
-
-class UnitOfWork(AbstractUnitOfWork):
-    session: AsyncSession
-
-    timestamps: TimestepRepo
-    imaging_events: ImagingEventRepo
-
-    def __init__(self, session_maker: async_sessionmaker[AsyncSession]):
-        self.session_maker = session_maker
-        self.messages = []
-
-    async def __aenter__(self) -> "UnitOfWork":
-        self.session = await self.session_maker().__aenter__()
-        self.timestamps = TimestepRepo(self.session)
-        self.imaging_events = ImagingEventRepo(self.session)
-        return self
-
-    async def __aexit__(self, exc_type, exc_value, exc_traceback):
-        await super().__aexit__(exc_type, exc_value, exc_traceback)
-        await self.session.close()
-
-    async def commit(self) -> None:
-        await self.session.commit()
-
-    async def rollback(self) -> None:
-        await self.session.rollback()
-
-    def add_message(self, message: BaseModel):
-        self.messages.append(message)
-
-    def collect_messages(self) -> Generator[BaseModel, None, None]:
-        while self.messages:
-            yield self.messages.pop(0)

--- a/prince-archiver/prince_archiver/data_archive/handlers.py
+++ b/prince-archiver/prince_archiver/data_archive/handlers.py
@@ -3,12 +3,12 @@ from typing import Callable
 
 from aio_pika.abc import AbstractIncomingMessage
 
-from prince_archiver.db import AbstractUnitOfWork
 from prince_archiver.models import (
     DataArchiveEntry,
     Timestep,
 )
 from prince_archiver.service_layer.messagebus import MessageBus
+from prince_archiver.service_layer.uow import AbstractUnitOfWork
 
 from .dto import UpdateArchiveEntries
 

--- a/prince-archiver/prince_archiver/data_archive/reporter.py
+++ b/prince-archiver/prince_archiver/data_archive/reporter.py
@@ -11,8 +11,8 @@ from jinja2 import Environment, PackageLoader
 from pydantic import BaseModel, Field, HttpUrl
 from s3fs import S3FileSystem
 
-from prince_archiver.db import UnitOfWork
 from prince_archiver.definitions import EventType
+from prince_archiver.service_layer.uow import UnitOfWork
 
 LOGGER = logging.getLogger(__name__)
 

--- a/prince-archiver/prince_archiver/data_archive/worker.py
+++ b/prince-archiver/prince_archiver/data_archive/worker.py
@@ -12,10 +12,10 @@ from httpx import AsyncClient
 from zoneinfo import ZoneInfo
 
 from prince_archiver.config import ArchiveWorkerSettings
-from prince_archiver.db import UnitOfWork, get_session_maker
 from prince_archiver.file import managed_file_system
 from prince_archiver.logging import configure_logging
 from prince_archiver.service_layer.messagebus import MessageBus
+from prince_archiver.service_layer.uow import UnitOfWork, get_session_maker
 
 from .archiver import AbstractArchiver, Settings, SurfArchiver
 from .dto import UpdateArchiveEntries

--- a/prince-archiver/prince_archiver/service_layer/messagebus.py
+++ b/prince-archiver/prince_archiver/service_layer/messagebus.py
@@ -3,7 +3,7 @@ from typing import Awaitable, Callable, Generic, Mapping, TypeVar
 
 from pydantic import BaseModel
 
-from prince_archiver.db import AbstractUnitOfWork
+from prince_archiver.service_layer.uow import AbstractUnitOfWork
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
 

--- a/prince-archiver/prince_archiver/service_layer/uow.py
+++ b/prince-archiver/prince_archiver/service_layer/uow.py
@@ -1,0 +1,81 @@
+from abc import ABC, abstractmethod
+from typing import Generator
+
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from prince_archiver.adapters.repository import (
+    AbstractImagingEventRepo,
+    AbstractTimestepRepo,
+    ImagingEventRepo,
+    TimestepRepo,
+)
+
+
+def get_session_maker(url: str) -> async_sessionmaker[AsyncSession]:
+    engine = create_async_engine(url)
+    return async_sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=engine,
+    )
+
+
+class AbstractUnitOfWork(ABC):
+    messages: list[BaseModel]
+
+    timestamps: AbstractTimestepRepo
+    imaging_events: AbstractImagingEventRepo
+
+    @abstractmethod
+    async def __aenter__(self) -> "AbstractUnitOfWork": ...
+
+    @abstractmethod
+    async def __aexit__(self, exc_type, exc_value, exc_traceback):
+        await self.rollback()
+
+    @abstractmethod
+    async def rollback(self) -> None: ...
+
+    @abstractmethod
+    async def commit(self) -> None: ...
+
+    @abstractmethod
+    def add_message(self, message: BaseModel): ...
+
+    @abstractmethod
+    def collect_messages(self) -> Generator[BaseModel, None, None]: ...
+
+
+class UnitOfWork(AbstractUnitOfWork):
+    session: AsyncSession
+
+    timestamps: TimestepRepo
+    imaging_events: ImagingEventRepo
+
+    def __init__(self, session_maker: async_sessionmaker[AsyncSession]):
+        self.session_maker = session_maker
+        self.messages = []
+
+    async def __aenter__(self) -> "UnitOfWork":
+        self.session = await self.session_maker().__aenter__()
+        self.timestamps = TimestepRepo(self.session)
+        self.imaging_events = ImagingEventRepo(self.session)
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, exc_traceback):
+        await super().__aexit__(exc_type, exc_value, exc_traceback)
+        await self.session.close()
+
+    async def commit(self) -> None:
+        await self.session.commit()
+
+    async def rollback(self) -> None:
+        await self.session.rollback()
+
+    def add_message(self, message: BaseModel):
+        self.messages.append(message)
+
+    def collect_messages(self) -> Generator[BaseModel, None, None]:
+        while self.messages:
+            yield self.messages.pop(0)

--- a/prince-archiver/prince_archiver/upload_worker/handlers.py
+++ b/prince-archiver/prince_archiver/upload_worker/handlers.py
@@ -9,10 +9,10 @@ from uuid import uuid4
 import s3fs
 from aiofiles.tempfile import TemporaryDirectory
 
-from prince_archiver.db import AbstractUnitOfWork
 from prince_archiver.file import tar
 from prince_archiver.models import ObjectStoreEntry
 from prince_archiver.service_layer.messagebus import AbstractHandler
+from prince_archiver.service_layer.uow import AbstractUnitOfWork
 
 from .dto import UploadDTO
 

--- a/prince-archiver/prince_archiver/upload_worker/worker.py
+++ b/prince-archiver/prince_archiver/upload_worker/worker.py
@@ -6,12 +6,12 @@ from arq.connections import RedisSettings
 
 from prince_archiver.config import WorkerSettings as _Settings
 from prince_archiver.config import get_worker_settings
-from prince_archiver.db import UnitOfWork, get_session_maker
 from prince_archiver.definitions import EventType
 from prince_archiver.dto import TimestepDTO
 from prince_archiver.file import managed_file_system
 from prince_archiver.logging import configure_logging
 from prince_archiver.service_layer.messagebus import MessageBus, MessagebusFactoryT
+from prince_archiver.service_layer.uow import UnitOfWork, get_session_maker
 
 from .dto import UploadDTO
 from .handlers import UploadHandler, add_upload_to_db

--- a/prince-archiver/prince_archiver/watcher/context.py
+++ b/prince-archiver/prince_archiver/watcher/context.py
@@ -6,9 +6,9 @@ from arq import create_pool
 from arq.connections import RedisSettings
 
 from prince_archiver.config import WatcherSettings
-from prince_archiver.db import UnitOfWork, get_session_maker
 from prince_archiver.dto import TimestepDTO
 from prince_archiver.service_layer.messagebus import MessageBus
+from prince_archiver.service_layer.uow import UnitOfWork, get_session_maker
 
 from .handlers import ArqHandler, add_to_db
 

--- a/prince-archiver/prince_archiver/watcher/handlers.py
+++ b/prince-archiver/prince_archiver/watcher/handlers.py
@@ -3,10 +3,10 @@ from datetime import UTC
 
 from arq import ArqRedis
 
-from prince_archiver.db import AbstractUnitOfWork
 from prince_archiver.dto import TimestepDTO
 from prince_archiver.models import Timestep
 from prince_archiver.service_layer.messagebus import AbstractHandler
+from prince_archiver.service_layer.uow import AbstractUnitOfWork
 
 LOGGER = logging.getLogger(__name__)
 

--- a/prince-archiver/tests/integration/test_imaging_events_repo.py
+++ b/prince-archiver/tests/integration/test_imaging_events_repo.py
@@ -5,7 +5,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from prince_archiver.db import ImagingEventRepo
+from prince_archiver.adapters.repository import ImagingEventRepo
 from prince_archiver.definitions import System
 from prince_archiver.domain.models import StitchEvent, StitchParams
 from prince_archiver.domain.value_objects import GridSize, Location

--- a/prince-archiver/tests/integration/test_repository.py
+++ b/prince-archiver/tests/integration/test_repository.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from prince_archiver.db import TimestepRepo
+from prince_archiver.adapters.repository import TimestepRepo
 from prince_archiver.models import ObjectStoreEntry, Timestep
 
 pytestmark = pytest.mark.integration

--- a/prince-archiver/tests/unit/data_archive/test_handlers.py
+++ b/prince-archiver/tests/unit/data_archive/test_handlers.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 from aio_pika.abc import AbstractIncomingMessage
 
+from prince_archiver.adapters.repository import AbstractTimestepRepo
 from prince_archiver.data_archive.dto import (
     Archive,
     UpdateArchiveEntries,
@@ -13,9 +14,9 @@ from prince_archiver.data_archive.handlers import (
     SubscriberMessageHandler,
     add_data_archive_entries,
 )
-from prince_archiver.db import AbstractTimestepRepo, AbstractUnitOfWork
 from prince_archiver.models import Timestep
 from prince_archiver.service_layer.messagebus import MessageBus
+from prince_archiver.service_layer.uow import AbstractUnitOfWork
 
 
 @pytest.fixture(name="update_archive_entries_msg")

--- a/prince-archiver/tests/unit/test_messagebus.py
+++ b/prince-archiver/tests/unit/test_messagebus.py
@@ -3,8 +3,8 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
 
-from prince_archiver.db import AbstractUnitOfWork
 from prince_archiver.service_layer.messagebus import MessageBus
+from prince_archiver.service_layer.uow import AbstractUnitOfWork
 
 
 class MockMessage(BaseModel):

--- a/prince-archiver/tests/unit/upload_worker/test_handlers.py
+++ b/prince-archiver/tests/unit/upload_worker/test_handlers.py
@@ -4,8 +4,9 @@ from uuid import uuid4
 
 import pytest
 
-from prince_archiver.db import AbstractTimestepRepo, AbstractUnitOfWork
+from prince_archiver.adapters.repository import AbstractTimestepRepo
 from prince_archiver.models import ObjectStoreEntry, Timestep
+from prince_archiver.service_layer.uow import AbstractUnitOfWork
 from prince_archiver.upload_worker.dto import UploadDTO
 from prince_archiver.upload_worker.handlers import add_upload_to_db
 


### PR DESCRIPTION
## Description
Move uow into service layer and repos into adapter module.


## Implementation
- moved uow from root to `service_layer` modules
- Decoupled repositories from `uow` and moved to `adapter` module
