### PR TITLE
prince-archiver: Add custom pathlib type

### DIFF
--- a/prince-archiver/prince_archiver/domain/models.py
+++ b/prince-archiver/prince_archiver/domain/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from uuid import UUID, uuid4
 
 from prince_archiver.definitions import EventType
@@ -48,7 +49,7 @@ class ImagingEvent:
         ref_id: UUID,
         type: EventType,
         experiment_id: str,
-        local_path: str,
+        local_path: Path,
         timestamp: datetime,
         *,
         event_archive: EventArchive | None = None,
@@ -81,7 +82,7 @@ class ImagingEvent:
         ref_id: UUID,
         type: EventType,
         experiment_id: str,
-        local_path: str,
+        local_path: Path,
         timestamp: datetime,
         *,
         _id: UUID | None = None,

--- a/prince-archiver/prince_archiver/models/types.py
+++ b/prince-archiver/prince_archiver/models/types.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import Dialect, String, TypeDecorator
+
+
+class PathType(TypeDecorator):
+    """
+    Custom type used to convert
+    """
+
+    impl = String
+
+    def process_bind_param(self, value: Any | None, dialect: Dialect) -> Any:
+        if isinstance(value, Path):
+            value = value.as_posix()
+        return value
+
+    def process_result_value(self, value: Any | None, dialect: Dialect) -> Any | None:
+        if isinstance(value, str):
+            return Path(value)
+        return value

--- a/prince-archiver/prince_archiver/models/v1.py
+++ b/prince-archiver/prince_archiver/models/v1.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from uuid import UUID, uuid4
 
 from sqlalchemy import ForeignKey
@@ -7,6 +8,8 @@ from sqlalchemy.types import TIMESTAMP, Uuid
 
 from prince_archiver.utils import now
 
+from .types import PathType
+
 
 class Base(DeclarativeBase):
     created_at: Mapped[datetime] = mapped_column(default=now)
@@ -14,6 +17,7 @@ class Base(DeclarativeBase):
 
     type_annotation_map = {
         datetime: TIMESTAMP(timezone=True),
+        Path: PathType,
     }
 
 

--- a/prince-archiver/prince_archiver/models/v2.py
+++ b/prince-archiver/prince_archiver/models/v2.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from typing import Annotated
 from uuid import UUID, uuid4
 
@@ -86,7 +87,7 @@ class ImagingEvent(Base):
         Enum(EventType, native_enum=False),
     )
     experiment_id: Mapped[str]
-    local_path: Mapped[str]
+    local_path: Mapped[Path]
     timestamp: Mapped[datetime]
 
     # TODO: remove these if not needed.

--- a/prince-archiver/prince_archiver/service_layer/messages.py
+++ b/prince-archiver/prince_archiver/service_layer/messages.py
@@ -29,7 +29,7 @@ ParamsT = Annotated[ImagingParams | VideoParams, Field(discriminator="type")]
 class ImportImagingEvent(BaseModel):
     ref_id: UUID
     experiment_id: str
-    local_path: str
+    local_path: Path
     timestamp: datetime
     type: EventType
 

--- a/prince-archiver/tests/integration/conftest.py
+++ b/prince-archiver/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import AsyncGenerator
 from uuid import UUID, uuid4
 
@@ -65,7 +66,7 @@ def fixture_imaging_event() -> data_models.ImagingEvent:
         ref_id=UUID("0b036a6a5ba745aea24290106014b08d"),
         type=EventType.STITCH,
         experiment_id="test_experiment_id",
-        local_path="/test/path/",
+        local_path=Path("test/path/"),
         system=System.PRINCE,
         system_position=3,
         timestamp=datetime(2000, 1, 1, tzinfo=UTC),

--- a/prince-archiver/tests/integration/test_imaging_events_repo.py
+++ b/prince-archiver/tests/integration/test_imaging_events_repo.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
@@ -21,7 +22,7 @@ async def test_add(repo: ImagingEventRepo):
     stitch_event = ImagingEvent.factory(
         ref_id=uuid4(),
         experiment_id="experiment_id",
-        local_path="/test/path/",
+        local_path=Path("test/path/"),
         timestamp=datetime.now(),
         type=EventType.STITCH,
     )

--- a/prince-archiver/tests/integration/test_mappers.py
+++ b/prince-archiver/tests/integration/test_mappers.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 from sqlalchemy import select
@@ -21,7 +22,7 @@ async def test_imaging_event_mappers(session: AsyncSession):
     assert imaging_event
     assert imaging_event.timestamp == datetime(2000, 1, 1, tzinfo=UTC)
     assert imaging_event.type == EventType.STITCH
-    assert imaging_event.local_path == "/test/path/"
+    assert imaging_event.local_path == Path("test/path/")
     assert imaging_event.experiment_id == "test_experiment_id"
 
     assert (object_store_entry := imaging_event.object_store_entry)

--- a/prince-archiver/tests/unit/conftest.py
+++ b/prince-archiver/tests/unit/conftest.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -30,7 +31,7 @@ def fixture_unexported_imaging_event() -> ImagingEvent:
         ref_id=uuid4(),
         type=EventType.STITCH,
         experiment_id="test_experiment_id",
-        local_path="unexported/path",
+        local_path=Path("unexported/path"),
         timestamp=datetime(2000, 1, 1, tzinfo=UTC),
     )
 
@@ -41,7 +42,7 @@ def fixture_exported_imaging_event() -> ImagingEvent:
         ref_id=uuid4(),
         type=EventType.STITCH,
         experiment_id="test_experiment_id",
-        local_path="exported/path",
+        local_path=Path("exported/path"),
         timestamp=datetime(2001, 1, 1, tzinfo=UTC),
     )
 


### PR DESCRIPTION
## Description
Extend `TypeDecorator` to facilitate storing `pathlib.Path` objects.


## Implementation
- Extend `TypeDecorator` overriding `process_bind_param` and `process_result_value` methods to allow for (de-/ serialization.
- Update `ImagingEvent` domain model to accept `Path` type
- Update `ImagingEvent` data model to accept `Path` type
- Update `ImportImagingEvent` to accept `Path` type
- Update tests accordingly