### PR TITLE
prince-archiver: Add read model for exports

### DIFF
--- a/prince-archiver/prince_archiver/adapters/repository.py
+++ b/prince-archiver/prince_archiver/adapters/repository.py
@@ -7,11 +7,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql import Select
 
-from prince_archiver.utils import now
 from prince_archiver.domain.models import DataArchiveEntry, ImagingEvent
 from prince_archiver.models import Timestep
 from prince_archiver.models import v2 as data_models
 from prince_archiver.models.read import Export
+from prince_archiver.utils import now
 
 
 class AbstractReadRepo(ABC):
@@ -21,8 +21,8 @@ class AbstractReadRepo(ABC):
 
     @abstractmethod
     async def get_exports(
-        self, 
-        start: datetime, 
+        self,
+        start: datetime,
         end: datetime | None = None,
     ) -> list[Export]: ...
 

--- a/prince-archiver/prince_archiver/adapters/repository.py
+++ b/prince-archiver/prince_archiver/adapters/repository.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import date
+from datetime import date, datetime
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -10,6 +10,42 @@ from sqlalchemy.sql import Select
 from prince_archiver.domain.models import DataArchiveEntry, ImagingEvent
 from prince_archiver.models import Timestep
 from prince_archiver.models import v2 as data_models
+from prince_archiver.models.read import Export
+
+
+class AbstractReadRepo(ABC):
+    """
+    Repository to be used with read models.
+    """
+
+    @abstractmethod
+    async def get_exports(
+        self, start: datetime, end: datetime | None = None
+    ) -> list[Export]: ...
+
+
+class ReadRepo:
+    """
+    Concrete read repository.
+    """
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_exports(
+        self,
+        start: datetime,
+        end: datetime | None = None,
+    ) -> list[Export]:
+        query_params = [
+            data_models.ObjectStoreEntry.uploaded_at > start,
+            data_models.ObjectStoreEntry.uploaded_at < (end or datetime.now()),
+        ]
+
+        result = await self.session.stream_scalars(
+            select(Export).where(*query_params),
+        )
+        return [item async for item in result]
 
 
 class AbstractDataArchiveEntryRepo(ABC):

--- a/prince-archiver/prince_archiver/adapters/repository.py
+++ b/prince-archiver/prince_archiver/adapters/repository.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql import Select
 
+from prince_archiver.utils import now
 from prince_archiver.domain.models import DataArchiveEntry, ImagingEvent
 from prince_archiver.models import Timestep
 from prince_archiver.models import v2 as data_models
@@ -20,11 +21,13 @@ class AbstractReadRepo(ABC):
 
     @abstractmethod
     async def get_exports(
-        self, start: datetime, end: datetime | None = None
+        self, 
+        start: datetime, 
+        end: datetime | None = None,
     ) -> list[Export]: ...
 
 
-class ReadRepo:
+class ReadRepo(AbstractReadRepo):
     """
     Concrete read repository.
     """
@@ -38,8 +41,8 @@ class ReadRepo:
         end: datetime | None = None,
     ) -> list[Export]:
         query_params = [
-            data_models.ObjectStoreEntry.uploaded_at > start,
-            data_models.ObjectStoreEntry.uploaded_at < (end or datetime.now()),
+            Export.uploaded_at > start,
+            Export.uploaded_at < (end or now()),
         ]
 
         result = await self.session.stream_scalars(

--- a/prince-archiver/prince_archiver/models/read.py
+++ b/prince-archiver/prince_archiver/models/read.py
@@ -1,0 +1,22 @@
+from sqlalchemy import select
+from sqlalchemy.orm import DeclarativeBase
+
+from .v2 import ImagingEvent, ObjectStoreEntry
+
+
+class ReadBase(DeclarativeBase):
+    pass
+
+
+class Export(ReadBase):
+    __table__ = (
+        select(
+            ImagingEvent.id,
+            ImagingEvent.ref_id,
+            ImagingEvent.experiment_id,
+            ObjectStoreEntry.key,
+            ObjectStoreEntry.uploaded_at,
+        )
+        .join(ImagingEvent)
+        .subquery()
+    )

--- a/prince-archiver/prince_archiver/models/read.py
+++ b/prince-archiver/prince_archiver/models/read.py
@@ -1,5 +1,8 @@
+from uuid import UUID
+from datetime import datetime
+
 from sqlalchemy import select
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import DeclarativeBase, Mapped
 
 from .v2 import ImagingEvent, ObjectStoreEntry
 
@@ -17,6 +20,12 @@ class Export(ReadBase):
             ObjectStoreEntry.key,
             ObjectStoreEntry.uploaded_at,
         )
-        .join(ImagingEvent)
+        .join_from(ObjectStoreEntry, ImagingEvent)
         .subquery()
     )
+
+    id: Mapped[UUID]
+    ref_id: Mapped[UUID]
+    experiment_id: Mapped[str]
+    key: Mapped[str]
+    uploaded_at: Mapped[datetime]

--- a/prince-archiver/prince_archiver/models/read.py
+++ b/prince-archiver/prince_archiver/models/read.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Mapped
 
+from prince_archiver.definitions import EventType
 from .v2 import ImagingEvent, ObjectStoreEntry
 
 
@@ -16,6 +17,7 @@ class Export(ReadBase):
         select(
             ImagingEvent.id,
             ImagingEvent.ref_id,
+            ImagingEvent.type,
             ImagingEvent.experiment_id,
             ObjectStoreEntry.key,
             ObjectStoreEntry.uploaded_at,
@@ -27,5 +29,6 @@ class Export(ReadBase):
     id: Mapped[UUID]
     ref_id: Mapped[UUID]
     experiment_id: Mapped[str]
+    type: Mapped[EventType]
     key: Mapped[str]
     uploaded_at: Mapped[datetime]

--- a/prince-archiver/prince_archiver/models/read.py
+++ b/prince-archiver/prince_archiver/models/read.py
@@ -1,10 +1,11 @@
-from uuid import UUID
 from datetime import datetime
+from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Mapped
 
 from prince_archiver.definitions import EventType
+
 from .v2 import ImagingEvent, ObjectStoreEntry
 
 

--- a/prince-archiver/tests/integration/test_read_repo.py
+++ b/prince-archiver/tests/integration/test_read_repo.py
@@ -5,7 +5,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from prince_archiver.adapters.repository import ReadRepo
 
-
 pytestmark = pytest.mark.integration
 
 
@@ -24,5 +23,3 @@ async def test_export_within_time_range(repo: ReadRepo):
 async def test_export_outside_time_range(repo: ReadRepo):
     result = await repo.get_exports(start=datetime(2010, 1, 1))
     assert len(result) == 0
-
-

--- a/prince-archiver/tests/integration/test_read_repo.py
+++ b/prince-archiver/tests/integration/test_read_repo.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prince_archiver.adapters.repository import ReadRepo
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def repo(session: AsyncSession) -> ReadRepo:
+    return ReadRepo(session)
+
+
+@pytest.mark.usefixtures("seed_data")
+async def test_export_within_time_range(repo: ReadRepo):
+    result = await repo.get_exports(start=datetime(1900, 1, 1))
+    assert len(result) == 1
+
+
+@pytest.mark.usefixtures("seed_data")
+async def test_export_outside_time_range(repo: ReadRepo):
+    result = await repo.get_exports(start=datetime(2010, 1, 1))
+    assert len(result) == 0
+
+


### PR DESCRIPTION
## Description
Add read model for providing exports


## Implementation
- Add `Export` model which is constructed from subquery
- Add repo for retrieving exports which can be filtered by time
