### PR TITLE
prince-archiver: Move v2 watcher into entrypoints

### DIFF
--- a/prince-archiver/compose.dev.yml
+++ b/prince-archiver/compose.dev.yml
@@ -9,7 +9,7 @@ x-aws-env-variables: &aws-env-variables
 services:
   prince:
     image: prince-archiver
-    command: ["python", "-m", "prince_archiver.test_utils.mock_prince"]
+    command: ["python", "-m", "prince_archiver.entrypoints.mock_prince"]
     environment:
       DATA_DIR: /data/input
     volumes:

--- a/prince-archiver/prince_archiver/config.py
+++ b/prince-archiver/prince_archiver/config.py
@@ -1,5 +1,4 @@
 import os
-from functools import lru_cache
 from pathlib import Path
 
 import sentry_sdk
@@ -67,8 +66,3 @@ class ArchiveWorkerSettings(AWSSettings, CommonSettings):
     WEBHOOK_URL: HttpUrl | None = None
 
     ARCHIVE_TRANSITION_DAYS: int = 2
-
-
-@lru_cache
-def get_worker_settings() -> WorkerSettings:
-    return WorkerSettings()

--- a/prince-archiver/prince_archiver/entrypoints/mock_prince.py
+++ b/prince-archiver/prince_archiver/entrypoints/mock_prince.py
@@ -8,11 +8,10 @@ from uuid import uuid4
 import httpx
 from fastapi import FastAPI, Response
 
-from prince_archiver.dto import TimestepMeta
 from prince_archiver.logging import configure_logging
+from prince_archiver.service_layer.external_dto import TimestepMeta
+from prince_archiver.test_utils.utils import make_timestep_directory
 from prince_archiver.utils import now
-
-from .utils import make_timestep_directory
 
 BASE_DIR = Path(os.environ.get("DATA_DIR", "/app/data"))
 

--- a/prince-archiver/prince_archiver/entrypoints/watcher/context.py
+++ b/prince-archiver/prince_archiver/entrypoints/watcher/context.py
@@ -1,16 +1,26 @@
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from functools import partial
 from typing import AsyncGenerator
 
 from arq import create_pool
 from arq.connections import RedisSettings
 
 from prince_archiver.config import WatcherSettings
-from prince_archiver.service_layer.external_dto import TimestepDTO
+from prince_archiver.models import init_mappers
+from prince_archiver.service_layer.handlers.importer import (
+    Context as _Context,
+)
+from prince_archiver.service_layer.handlers.importer import (
+    import_imaging_event,
+    propagate_new_imaging_event,
+)
 from prince_archiver.service_layer.messagebus import MessageBus
+from prince_archiver.service_layer.messages import (
+    ImportedImagingEvent,
+    ImportImagingEvent,
+)
 from prince_archiver.service_layer.uow import UnitOfWork, get_session_maker
-
-from .handlers import ArqHandler, add_to_db
 
 
 @dataclass
@@ -26,17 +36,26 @@ async def managed_context(
 ) -> AsyncGenerator[Context, None]:
     settings = _settings or WatcherSettings()
 
+    init_mappers()
+
     redis = await create_pool(
         RedisSettings.from_dsn(str(settings.REDIS_DSN)),
     )
 
     messagebus = MessageBus(
-        handlers={TimestepDTO: [add_to_db, ArqHandler(redis)]},
+        handlers={
+            ImportImagingEvent: [import_imaging_event],
+            ImportedImagingEvent: [
+                partial(
+                    propagate_new_imaging_event,
+                    context=_Context(redis_client=redis),
+                )
+            ],
+        },
         uow=UnitOfWork(
             get_session_maker(str(settings.POSTGRES_DSN)),
         ),
     )
 
     yield Context(settings=settings, messagebus=messagebus)
-
     await redis.aclose()

--- a/prince-archiver/prince_archiver/entrypoints/watcher/main.py
+++ b/prince-archiver/prince_archiver/entrypoints/watcher/main.py
@@ -1,0 +1,56 @@
+import asyncio
+import logging
+from pathlib import Path
+
+from watchfiles import Change, awatch
+
+from prince_archiver.config import WatcherSettings
+from prince_archiver.logging import configure_logging
+from prince_archiver.utils import parse_timestep_dir
+
+from .context import Context, managed_context
+from .utils import map_external_dto
+
+
+async def process_backlog(context: Context):
+    for filepath in context.settings.EVENTS_DIR.iterdir():
+        data = map_external_dto(
+            parse_timestep_dir(filepath),
+        )
+        await context.messagebus.handle(data)
+
+        filepath.unlink()
+
+
+async def watch(context: Context):
+    watcher = awatch(
+        context.settings.EVENTS_DIR,
+        watch_filter=lambda change, _: change == Change.added,
+        force_polling=context.settings.WATCHFILES_FORCE_POLLING,
+        recursive=False,
+    )
+    async for changes in watcher:
+        for _, _filepath in changes:
+            filepath = Path(_filepath)
+
+            data = map_external_dto(
+                parse_timestep_dir(filepath),
+            )
+            await context.messagebus.handle(data)
+
+            filepath.unlink()
+
+
+async def amain(*, _settings: WatcherSettings | None = None):
+    async with managed_context(_settings=_settings) as context:
+        logging.info("Watching %s", context.settings.DATA_DIR)
+        await watch(context)
+
+
+def main():
+    configure_logging()
+    asyncio.run(amain())
+
+
+if __name__ == "__main__":
+    main()

--- a/prince-archiver/prince_archiver/entrypoints/watcher/utils.py
+++ b/prince-archiver/prince_archiver/entrypoints/watcher/utils.py
@@ -1,0 +1,13 @@
+from prince_archiver.definitions import EventType
+from prince_archiver.service_layer.external_dto import TimestepDTO
+from prince_archiver.service_layer.messages import ImportImagingEvent
+
+
+def map_external_dto(timestep_dto: TimestepDTO) -> ImportImagingEvent:
+    return ImportImagingEvent(
+        ref_id=timestep_dto.timestep_id,
+        experiment_id=timestep_dto.experiment_id,
+        local_path=timestep_dto.img_dir,
+        timestamp=timestep_dto.timestamp,
+        type=EventType.STITCH,
+    )

--- a/prince-archiver/prince_archiver/service_layer/external_dto.py
+++ b/prince-archiver/prince_archiver/service_layer/external_dto.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 
 from pydantic import AwareDatetime, BaseModel, Field, model_validator
 
-from .definitions import EventType
+from prince_archiver.definitions import EventType
 
 
 class TimestepMeta(BaseModel):

--- a/prince-archiver/prince_archiver/test_utils/cli.py
+++ b/prince-archiver/prince_archiver/test_utils/cli.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import typer
 
-from prince_archiver.dto import TimestepMeta
+from prince_archiver.service_layer.external_dto import TimestepMeta
 
 from .utils import make_timestep_directory as _make_timestep_directory
 

--- a/prince-archiver/prince_archiver/test_utils/utils.py
+++ b/prince-archiver/prince_archiver/test_utils/utils.py
@@ -5,7 +5,7 @@ from timeit import default_timer
 
 import httpx
 
-from prince_archiver.dto import TimestepMeta
+from prince_archiver.service_layer.external_dto import TimestepMeta
 
 DOWNLOAD_URL = "https://vu.data.surfsara.nl/index.php/s/ndI1UoMRwliVYGR/download"
 

--- a/prince-archiver/prince_archiver/upload_worker/worker.py
+++ b/prince-archiver/prince_archiver/upload_worker/worker.py
@@ -4,12 +4,11 @@ from contextlib import AsyncExitStack
 
 from arq.connections import RedisSettings
 
-from prince_archiver.config import WorkerSettings as _Settings
-from prince_archiver.config import get_worker_settings
+from prince_archiver.config import UploadWorkerSettings as _Settings
 from prince_archiver.definitions import EventType
-from prince_archiver.dto import TimestepDTO
 from prince_archiver.file import managed_file_system
 from prince_archiver.logging import configure_logging
+from prince_archiver.service_layer.external_dto import TimestepDTO
 from prince_archiver.service_layer.messagebus import MessageBus, MessagebusFactoryT
 from prince_archiver.service_layer.uow import UnitOfWork, get_session_maker
 
@@ -45,7 +44,7 @@ async def startup(ctx):
 
     exit_stack = await AsyncExitStack().__aenter__()
 
-    settings = get_worker_settings()
+    settings = _Settings()
 
     s3 = await exit_stack.enter_async_context(managed_file_system(settings))
     sessionmaker = get_session_maker(str(settings.POSTGRES_DSN))

--- a/prince-archiver/prince_archiver/upload_worker/worker.py
+++ b/prince-archiver/prince_archiver/upload_worker/worker.py
@@ -4,7 +4,7 @@ from contextlib import AsyncExitStack
 
 from arq.connections import RedisSettings
 
-from prince_archiver.config import UploadWorkerSettings as _Settings
+from prince_archiver.config import WorkerSettings as _Settings
 from prince_archiver.definitions import EventType
 from prince_archiver.file import managed_file_system
 from prince_archiver.logging import configure_logging

--- a/prince-archiver/prince_archiver/utils.py
+++ b/prince-archiver/prince_archiver/utils.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Generator
 
-from .dto import TimestepDTO
+from .service_layer.external_dto import TimestepDTO
 
 
 def now() -> datetime:

--- a/prince-archiver/prince_archiver/watcher/handlers.py
+++ b/prince-archiver/prince_archiver/watcher/handlers.py
@@ -3,8 +3,8 @@ from datetime import UTC
 
 from arq import ArqRedis
 
-from prince_archiver.dto import TimestepDTO
 from prince_archiver.models import Timestep
+from prince_archiver.service_layer.external_dto import TimestepDTO
 from prince_archiver.service_layer.messagebus import AbstractHandler
 from prince_archiver.service_layer.uow import AbstractUnitOfWork
 

--- a/prince-archiver/tests/e2e/steps/upload.py
+++ b/prince-archiver/tests/e2e/steps/upload.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from prince_archiver.definitions import EventType
-from prince_archiver.dto import TimestepMeta
+from prince_archiver.service_layer.external_dto import TimestepMeta
 from prince_archiver.test_utils.utils import Timer
 
 

--- a/prince-archiver/tests/unit/test_external_dto.py
+++ b/prince-archiver/tests/unit/test_external_dto.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import pytest
 
-from prince_archiver.dto import TimestepDTO, TimestepMeta
+from prince_archiver.service_layer.external_dto import TimestepDTO, TimestepMeta
 
 
 @dataclass


### PR DESCRIPTION
## Description
Move mock prince and v2 watcher into `prince_archiver.entrpoints`


## Implementation
- Move mock prince to `prince_archiver.entyrpoints.mock_prince`
- Move `prince_archiver.dto` -> `prince_archiver.service_layer.exteral_dto` + refactor associated imports
- Remove `get_worker_settings` function
