### PR TITLE
prince-archiver: Add service layer functionality for populating src dir info

### DIFF
--- a/prince-archiver/prince_archiver/domain/exceptions.py
+++ b/prince-archiver/prince_archiver/domain/exceptions.py
@@ -1,0 +1,2 @@
+class DomainException(Exception):
+    pass

--- a/prince-archiver/prince_archiver/domain/models.py
+++ b/prince-archiver/prince_archiver/domain/models.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 from uuid import UUID, uuid4
 
 from prince_archiver.definitions import EventType
 
+from .exceptions import DomainException
 from .value_objects import Checksum
 
 
@@ -29,8 +31,13 @@ class DataArchiveEntry:
 
 
 @dataclass
+class SrcDirInfo:
+    img_count: int
+    raw_metadata: dict[str, Any]
+
+
+@dataclass
 class EventArchive:
-    id: UUID
     size: int
     checksum: Checksum | None = None
 
@@ -51,6 +58,7 @@ class ImagingEvent:
         local_path: Path,
         timestamp: datetime,
         *,
+        src_dir_info: SrcDirInfo | None = None,
         event_archive: EventArchive | None = None,
         object_store_entry: ObjectStoreEntry | None = None,
     ):
@@ -62,17 +70,23 @@ class ImagingEvent:
         self.timestamp = timestamp
         self.experiment_id = experiment_id
 
+        self.src_dir_info = src_dir_info
         self.event_archive = event_archive
         self.object_store_entry = object_store_entry
 
+    def add_src_dir_info(self, src_dir_info: SrcDirInfo):
+        if self.src_dir_info:
+            raise DomainException("Already associated.")
+        self.src_dir_info = src_dir_info
+
     def add_event_archive(self, event_archive: EventArchive):
         if self.event_archive:
-            raise ValueError("error")
+            raise DomainException("Already associated")
         self.event_archive = event_archive
 
     def add_object_store_entry(self, object_store_entry: ObjectStoreEntry):
         if self.object_store_entry:
-            raise ValueError("error")
+            raise DomainException("Already associated")
         self.object_store_entry = object_store_entry
 
     @classmethod

--- a/prince-archiver/prince_archiver/models/mappers.py
+++ b/prince-archiver/prince_archiver/models/mappers.py
@@ -50,6 +50,18 @@ def init_mappers():
         exclude_properties=get_exclude_fields(data_models.ObjectStoreEntry),
     )
 
+    src_dir_mapper = mapper_registry.map_imperatively(
+        domain_models.SrcDirInfo,
+        data_models.SrcDirInfo.__table__,
+        properties={
+            "_imaging_event_id": (data_models.SrcDirInfo.imaging_event_id.expression,)
+        },
+        exclude_properties=[
+            data_models.SrcDirInfo.id,
+            *get_exclude_fields(data_models.SrcDirInfo),
+        ],
+    )
+
     archive_checksum_mapper = mapper_registry.map_imperatively(
         vo.Checksum,
         data_models.ArchiveChecksum.__table__,
@@ -73,13 +85,20 @@ def init_mappers():
                 uselist=False,
             ),
         },
-        exclude_properties=get_exclude_fields(data_models.EventArchive),
+        exclude_properties=[
+            data_models.EventArchive.id,
+            *get_exclude_fields(data_models.EventArchive),
+        ],
     )
 
     mapper_registry.map_imperatively(
         domain_models.ImagingEvent,
         data_models.ImagingEvent.__table__,
         properties={
+            "src_dir_info": relationship(
+                src_dir_mapper,
+                uselist=False,
+            ),
             "event_archive": relationship(
                 event_archive_mapper,
                 uselist=False,

--- a/prince-archiver/prince_archiver/models/v2.py
+++ b/prince-archiver/prince_archiver/models/v2.py
@@ -104,6 +104,7 @@ class ImagingEvent(Base):
 
     # TODO: remove these if not needed.
     system: Mapped[System | None] = mapped_column(
-        Enum(System, native_enum=False), nullable=True
+        Enum(System, native_enum=False),
+        nullable=True,
     )
     system_position: Mapped[int | None]

--- a/prince-archiver/prince_archiver/service_layer/handlers/exporter.py
+++ b/prince-archiver/prince_archiver/service_layer/handlers/exporter.py
@@ -5,7 +5,6 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
-from uuid import uuid4
 
 import s3fs
 
@@ -117,7 +116,6 @@ async def persist_imaging_event_export(
 
         imaging_event.add_event_archive(
             EventArchive(
-                id=uuid4(),
                 size=message.size,
                 checksum=message.checksum,
             )

--- a/prince-archiver/prince_archiver/service_layer/handlers/importer.py
+++ b/prince-archiver/prince_archiver/service_layer/handlers/importer.py
@@ -1,11 +1,13 @@
 """Handlers used to import imaging event into system."""
 
+import asyncio
 import logging
 from dataclasses import dataclass
 
 from arq import ArqRedis
 
-from prince_archiver.domain.models import ImagingEvent
+from prince_archiver.adapters.file import ArchiveFileManager
+from prince_archiver.domain.models import ImagingEvent, SrcDirInfo
 from prince_archiver.service_layer import messages
 from prince_archiver.service_layer.exceptions import ServiceLayerException
 from prince_archiver.service_layer.uow import AbstractUnitOfWork
@@ -38,7 +40,49 @@ async def import_imaging_event(
 
 
 @dataclass
-class Context:
+class SrcDirContext:
+    file_manager: ArchiveFileManager
+
+
+async def get_src_dir_info(
+    message: messages.ImportedImagingEvent,
+    uow: AbstractUnitOfWork,
+    *,
+    context: SrcDirContext,
+):
+    async with uow:
+        file_manager = context.file_manager
+        src_path = file_manager.get_src_path(message.local_path)
+        async with asyncio.TaskGroup() as tg:
+            t1 = tg.create_task(file_manager.get_file_count(src_path))
+            t2 = tg.create_task(file_manager.get_raw_metadata(src_path))
+
+        uow.add_message(
+            messages.AddSrcDirInfo(
+                ref_id=message.ref_id,
+                img_count=t1.result(),
+                raw_metadata=t2.result(),
+            )
+        )
+
+
+async def add_src_dir_info(
+    message: messages.AddSrcDirInfo,
+    uow: AbstractUnitOfWork,
+):
+    async with uow:
+        if imaging_event := await uow.imaging_events.get_by_ref_id(message.ref_id):
+            imaging_event.add_src_dir_info(
+                SrcDirInfo(
+                    img_count=message.img_count,
+                    raw_metadata=message.raw_metadata,
+                )
+            )
+        await uow.commit()
+
+
+@dataclass
+class PropagateContext:
     redis_client: ArqRedis
 
 
@@ -46,7 +90,7 @@ async def propagate_new_imaging_event(
     message: messages.ImportedImagingEvent,
     uow: AbstractUnitOfWork,
     *,
-    context: Context,
+    context: PropagateContext,
 ):
     async with uow:
         dto = messages.InitiateExportEvent(

--- a/prince-archiver/prince_archiver/service_layer/messages.py
+++ b/prince-archiver/prince_archiver/service_layer/messages.py
@@ -22,6 +22,12 @@ class ImportedImagingEvent(ImportImagingEvent):
     id: UUID
 
 
+class AddSrcDirInfo(BaseModel):
+    ref_id: UUID
+    img_count: int
+    raw_metadata: dict
+
+
 # For Exporting events out
 class InitiateExportEvent(BaseModel):
     ref_id: UUID

--- a/prince-archiver/tests/integration/conftest.py
+++ b/prince-archiver/tests/integration/conftest.py
@@ -124,18 +124,32 @@ def fixture_checksum(event_archive: data_models.EventArchive):
     )
 
 
+@pytest.fixture(name="src_dir_info")
+def fixture_src_dir_info(
+    imaging_event: data_models.ImagingEvent,
+) -> data_models.SrcDirInfo:
+    return data_models.SrcDirInfo(
+        id=uuid4(),
+        img_count=10,
+        raw_metadata={"test_key": "test_value"},
+        imaging_event_id=imaging_event.id,
+    )
+
+
 @pytest.fixture(name="seed_data")
 async def fixture_seed_data(
     data_archive_entry: data_models.DataArchiveEntry,
     imaging_event: data_models.ImagingEvent,
     data_archive_member: data_models.DataArchiveMember,
     object_store_entry: data_models.ObjectStoreEntry,
+    src_dir_info: data_models.SrcDirInfo,
     event_archive: data_models.EventArchive,
     checksum: data_models.ArchiveChecksum,
     session: AsyncSession,
 ):
     items = [
         imaging_event,
+        src_dir_info,
         event_archive,
         checksum,
         object_store_entry,

--- a/prince-archiver/tests/integration/test_archive_file_manager.py
+++ b/prince-archiver/tests/integration/test_archive_file_manager.py
@@ -1,3 +1,4 @@
+import json
 import tarfile
 from hashlib import sha256
 from pathlib import Path
@@ -84,3 +85,42 @@ async def test_get_size(
     size = await archive_file_manager.get_archive_size(ArchivePath(temp_file))
 
     assert size == temp_file.stat().st_size
+
+
+async def test_exists(
+    archive_file_manager: ArchiveFileManager,
+    temp_file: Path,
+):
+    # Test non existent file
+    assert not await archive_file_manager.exists(temp_file)
+
+    # # test existent file
+    temp_file.touch()
+    assert await archive_file_manager.exists(temp_file)
+
+
+async def test_get_raw_metadata_valid_json(
+    archive_file_manager: ArchiveFileManager,
+    temp_file: Path,
+):
+    src_data = {"key": "value"}
+    temp_file.write_text(json.dumps(src_data))
+
+    out_data = await archive_file_manager.get_raw_metadata(
+        SrcPath(temp_file.parent),
+        filename=temp_file.name,
+    )
+
+    assert src_data == out_data
+
+
+async def test_get_raw_metadata_file_missing(
+    archive_file_manager: ArchiveFileManager,
+    temp_file: Path,
+):
+    out_data = await archive_file_manager.get_raw_metadata(
+        SrcPath(temp_file.parent),
+        filename=temp_file.name,
+    )
+
+    assert out_data == {}

--- a/prince-archiver/tests/integration/test_mappers.py
+++ b/prince-archiver/tests/integration/test_mappers.py
@@ -33,6 +33,10 @@ async def test_imaging_event_mappers(session: AsyncSession):
     assert event_archive.size == 3
     assert event_archive.checksum == Checksum(hex="test_hex")
 
+    assert (src_dir_info := imaging_event.src_dir_info)
+    assert src_dir_info.img_count == 10
+    assert src_dir_info.raw_metadata == {"test_key": "test_value"}
+
 
 @pytest.mark.usefixtures("seed_data")
 async def test_data_archive_mappers(session: AsyncSession):

--- a/prince-archiver/tests/unit/conftest.py
+++ b/prince-archiver/tests/unit/conftest.py
@@ -48,7 +48,6 @@ def fixture_exported_imaging_event() -> ImagingEvent:
 
     imaging_event.add_event_archive(
         EventArchive(
-            id=uuid4(),
             size=10,
             checksum=Checksum(hex="321"),
         )

--- a/prince-archiver/tests/unit/handlers/conftest.py
+++ b/prince-archiver/tests/unit/handlers/conftest.py
@@ -1,6 +1,11 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+
 import pytest
 
+from prince_archiver.adapters.file import ArchiveFileManager
 from prince_archiver.domain.models import ImagingEvent
+from prince_archiver.domain.value_objects import Checksum
 
 from .utils import MockImagingEventRepo, MockUnitOfWork
 
@@ -15,3 +20,18 @@ def fixture_uow(
             imaging_events=[exported_imaging_event, unexported_imaging_event],
         ),
     )
+
+
+@pytest.fixture()
+def mock_file_manager() -> ArchiveFileManager:
+    mock_file_manager = AsyncMock(ArchiveFileManager)
+
+    mock_file_manager.get_archive_checksum.return_value = Checksum(hex="test")
+    mock_file_manager.get_archive_size.return_value = 1024
+    mock_file_manager.get_temp_archive.return_value.__aenter__ = AsyncMock(
+        return_value=Path("test")
+    )
+    mock_file_manager.get_file_count.return_value = 5
+    mock_file_manager.get_raw_metadata.return_value = {"test_key": "test_value"}
+
+    return mock_file_manager

--- a/prince-archiver/tests/unit/handlers/test_exporter.py
+++ b/prince-archiver/tests/unit/handlers/test_exporter.py
@@ -30,17 +30,6 @@ from .utils import MockUnitOfWork
 HandlerT = Callable[[InitiateExportEvent, AbstractUnitOfWork], Awaitable[None]]
 
 
-@pytest.fixture(name="mock_file_manager")
-def fixture_mock_file_manager() -> ArchiveFileManager:
-    mock = AsyncMock(ArchiveFileManager)
-
-    mock.get_archive_checksum.return_value = Checksum(hex="test")
-    mock.get_archive_size.return_value = 1024
-    mock.get_temp_archive.return_value.__aenter__ = AsyncMock(return_value=Path("test"))
-
-    return mock
-
-
 @pytest.fixture(name="context_bound_handler")
 def fixture_context_bound_handler() -> HandlerT:
     context = Context(


### PR DESCRIPTION
## Description
Add functionality for adding `SrcDirInfo` to `ImagingEvents`


## Implementation
- Extend `FileArchiveManager`
- Add data to domain mappers
- Add messages and service layer integration
- Add tests
