### PR TITLE
DA-29 prince-archiver: Ensure that queue is durable

### DIFF
--- a/prince-archiver/prince_archiver/adapters/subscriber.py
+++ b/prince-archiver/prince_archiver/adapters/subscriber.py
@@ -46,7 +46,7 @@ class ManagedSubscriber:
             durable=True,
             exclusive=True,
         )
-    
+
         await queue.bind(exchange)
         await queue.consume(self.message_handler)
 

--- a/prince-archiver/prince_archiver/adapters/subscriber.py
+++ b/prince-archiver/prince_archiver/adapters/subscriber.py
@@ -42,7 +42,11 @@ class ManagedSubscriber:
             self.exchange_config.type,
         )
 
-        queue = await channel.declare_queue(exclusive=True)
+        queue = await channel.declare_queue(
+            durable=True,
+            exclusive=True,
+        )
+    
         await queue.bind(exchange)
         await queue.consume(self.message_handler)
 


### PR DESCRIPTION
## Description
Ensure that subscriber queue is durable


## Implementation
- add `durable=True` when declaring queue
